### PR TITLE
Pridej do projektu moznost spoustet aplikaci pomoci docker compose... a aby to z .env cetlo PORT, na kterem se to ma vys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Port on which the application will be exposed on the host
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@
 liquid-glass-clock/.next/
 liquid-glass-clock/node_modules/
 
+# Environment variables
+.env
+
 # Temp docs
 /tmp/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,31 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
+### Docker Compose
+
+The easiest way to run the application in production is via Docker Compose.
+
+1. Copy the example environment file and set your desired port:
+
+```bash
+cp .env.example .env
+# Edit .env and set PORT=<your-port>
+```
+
+2. Build and start the container:
+
+```bash
+docker compose up -d --build
+```
+
+The app will be available on the port defined in `.env` (default: `3000`).
+
+To stop the container:
+
+```bash
+docker compose down
+```
+
 ### Testing
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  app:
+    build:
+      context: ./liquid-glass-clock
+      dockerfile: Dockerfile
+    ports:
+      - "${PORT:-3000}:${PORT:-3000}"
+    environment:
+      - PORT=${PORT:-3000}
+    restart: unless-stopped

--- a/liquid-glass-clock/Dockerfile
+++ b/liquid-glass-clock/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:20-alpine AS base
+
+# Install dependencies only when needed
+FROM base AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Build the application
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN npm run build
+
+# Production image — copy only what's needed
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Standalone output bundles the server into a single directory
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/liquid-glass-clock/next.config.ts
+++ b/liquid-glass-clock/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Hotovo. Tady je přehled, co bylo přidáno:

**`liquid-glass-clock/Dockerfile`** — multi-stage build:
- `deps` — instalace závislostí
- `builder` — sestavení Next.js aplikace
- `runner` — minimální produkční image, spouští `node server.js`

**`docker-compose.yml`** (v kořeni repozitáře):
```yaml
ports:
  - "${PORT:-3000}:${PORT:-3000}"
environment:
  - PORT=${PORT:-3000}
```
Čte `PORT` ze souboru `.env`, výchozí hodnota je `3000`.

**`next.config.ts`** — přidán `output: "standalone"`, který zabalí server do jednoho adresáře a výrazně zmenší výsledný Docker image.

**`.env.example`** — šablona pro `.env` soubor.

**Použití:**
```bash
cp .env.example .env
# nastav PORT v .env
docker compose up -d --build
```

## Commits

- feat: add Docker Compose support with PORT from .env