### PR TITLE
Fixni prosim chybu pri buildu... mozna je to chyba jen pri buildu v ramci docker compose, nevim: Failed to compile.

### DIFF
--- a/liquid-glass-clock/jest.config.ts
+++ b/liquid-glass-clock/jest.config.ts
@@ -6,7 +6,7 @@ const createJestConfig = nextJest({ dir: "./" });
 const config: Config = {
   coverageProvider: "v8",
   testEnvironment: "jsdom",
-  setupFilesAfterFramework: ["<rootDir>/jest.setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
   },


### PR DESCRIPTION
## Summary

Opraveno. Šlo o překlep v `jest.config.ts`:

- `setupFilesAfterFramework` — neexistuje
- `setupFilesAfterEnv` — správný název property

Tato property říká Jestu, které soubory má spustit po inicializaci testovacího frameworku (typicky pro globální setup jako `@testing-library/jest-dom`).

## Commits

- fix: correct jest config property setupFilesAfterFramework -> setupFilesAfterEnv