### PR TITLE
Pridej, aby kdyz bude dostupna nova verze stranky, aby se ukazal dialog, kde bude tlacitko refreshnout... Verze stranky 

### DIFF
--- a/liquid-glass-clock/__tests__/UpdateNotification.test.tsx
+++ b/liquid-glass-clock/__tests__/UpdateNotification.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+jest.mock("@/hooks/useVersionCheck", () => ({
+  useVersionCheck: jest.fn(),
+}));
+
+import UpdateNotification from "../components/UpdateNotification";
+import { useVersionCheck } from "@/hooks/useVersionCheck";
+
+const mockUseVersionCheck = useVersionCheck as jest.Mock;
+
+describe("UpdateNotification component", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders nothing when no update is available", () => {
+    mockUseVersionCheck.mockReturnValue({ updateAvailable: false });
+    const { container } = render(<UpdateNotification />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the notification dialog when update is available", () => {
+    mockUseVersionCheck.mockReturnValue({ updateAvailable: true });
+    render(<UpdateNotification />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/dostupná nová verze/i)).toBeInTheDocument();
+  });
+
+  it("shows the refresh button", () => {
+    mockUseVersionCheck.mockReturnValue({ updateAvailable: true });
+    render(<UpdateNotification />);
+    expect(screen.getByRole("button", { name: /obnovit stránku/i })).toBeInTheDocument();
+  });
+
+  it("refresh button click triggers reload (verifies onClick is wired)", () => {
+    mockUseVersionCheck.mockReturnValue({ updateAvailable: true });
+
+    // jsdom's window.location.reload is not callable in tests, but we can
+    // verify the button click does not throw a React error.
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(<UpdateNotification />);
+    // Should not throw
+    expect(() =>
+      fireEvent.click(screen.getByRole("button", { name: /obnovit stránku/i }))
+    ).not.toThrow();
+
+    consoleError.mockRestore();
+  });
+
+  it("has correct aria attributes for accessibility", () => {
+    mockUseVersionCheck.mockReturnValue({ updateAvailable: true });
+    render(<UpdateNotification />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-live", "polite");
+    expect(dialog).toHaveAttribute("aria-label", "Dostupná nová verze");
+  });
+});

--- a/liquid-glass-clock/__tests__/useVersionCheck.test.tsx
+++ b/liquid-glass-clock/__tests__/useVersionCheck.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { useVersionCheck } from "@/hooks/useVersionCheck";
+
+describe("useVersionCheck hook", () => {
+  let fetchMock: jest.Mock;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock;
+    jest.useFakeTimers();
+    process.env = { ...originalEnv, NEXT_PUBLIC_BUILD_ID: "abc123" };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  it("starts with updateAvailable = false", () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "abc123" }),
+    });
+
+    const { result } = renderHook(() => useVersionCheck());
+    expect(result.current.updateAvailable).toBe(false);
+  });
+
+  it("does not flag update when server version matches current version", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "abc123" }),
+    });
+
+    const { result } = renderHook(() => useVersionCheck());
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(result.current.updateAvailable).toBe(false);
+  });
+
+  it("flags update when server returns a different version", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "xyz999" }),
+    });
+
+    const { result } = renderHook(() => useVersionCheck());
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.updateAvailable).toBe(true);
+    });
+  });
+
+  it("ignores fetch errors gracefully", async () => {
+    fetchMock.mockRejectedValue(new Error("Network error"));
+
+    const { result } = renderHook(() => useVersionCheck());
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(result.current.updateAvailable).toBe(false);
+  });
+
+  it("ignores non-ok fetch responses", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+
+    const { result } = renderHook(() => useVersionCheck());
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(result.current.updateAvailable).toBe(false);
+  });
+
+  it("polls on a 60-second interval", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "abc123" }),
+    });
+
+    renderHook(() => useVersionCheck());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears interval on unmount", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "abc123" }),
+    });
+
+    const { unmount } = renderHook(() => useVersionCheck());
+
+    unmount();
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    // After unmount no further polls should happen
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/liquid-glass-clock/app/api/version/route.ts
+++ b/liquid-glass-clock/app/api/version/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json({
+    version: process.env.NEXT_PUBLIC_BUILD_ID ?? "dev",
+  });
+}

--- a/liquid-glass-clock/app/layout.tsx
+++ b/liquid-glass-clock/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import UpdateNotification from "@/components/UpdateNotification";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -20,6 +21,7 @@ export default function RootLayout({
   return (
     <html lang="cs" className="h-full">
       <body className={`${inter.className} antialiased h-full`}>
+        <UpdateNotification />
         {children}
       </body>
     </html>

--- a/liquid-glass-clock/components/UpdateNotification.tsx
+++ b/liquid-glass-clock/components/UpdateNotification.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useVersionCheck } from "@/hooks/useVersionCheck";
+
+export default function UpdateNotification() {
+  const { updateAvailable } = useVersionCheck();
+
+  if (!updateAvailable) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-live="polite"
+      aria-label="Dostupná nová verze"
+      className="fixed top-5 left-1/2 z-[200] -translate-x-1/2"
+      style={{
+        width: "min(360px, calc(100vw - 2.5rem))",
+        background: "rgba(10, 8, 28, 0.92)",
+        backdropFilter: "blur(48px) saturate(200%)",
+        WebkitBackdropFilter: "blur(48px) saturate(200%)",
+        border: "1px solid rgba(255,255,255,0.14)",
+        borderRadius: "1.75rem",
+        boxShadow:
+          "0 16px 48px rgba(0,0,0,0.6), 0 4px 16px rgba(100,80,255,0.18), inset 0 1px 0 rgba(255,255,255,0.14)",
+        padding: "1.25rem 1.5rem 1.25rem",
+        display: "flex",
+        alignItems: "center",
+        gap: "1rem",
+      }}
+    >
+      {/* Icon */}
+      <div
+        style={{
+          width: "36px",
+          height: "36px",
+          borderRadius: "10px",
+          background:
+            "linear-gradient(135deg, rgba(120,80,255,0.9), rgba(80,160,255,0.9))",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          boxShadow: "0 2px 10px rgba(100,80,255,0.45)",
+          flexShrink: 0,
+        }}
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            stroke="white"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+
+      {/* Text */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p
+          className="text-white/90 font-semibold"
+          style={{ fontSize: "0.88rem", lineHeight: 1.3 }}
+        >
+          Dostupná nová verze
+        </p>
+        <p
+          className="text-white/40"
+          style={{ fontSize: "0.72rem", marginTop: "2px" }}
+        >
+          Stránka byla aktualizována
+        </p>
+      </div>
+
+      {/* Refresh button */}
+      <button
+        onClick={() => window.location.reload()}
+        aria-label="Obnovit stránku"
+        className="font-medium transition-all active:scale-95"
+        style={{
+          padding: "0.5rem 1rem",
+          borderRadius: "0.875rem",
+          fontSize: "0.82rem",
+          background:
+            "linear-gradient(135deg, rgba(120,80,255,0.85), rgba(80,160,255,0.85))",
+          color: "white",
+          border: "1px solid rgba(120,80,255,0.4)",
+          boxShadow: "0 4px 16px rgba(100,80,255,0.3)",
+          cursor: "pointer",
+          whiteSpace: "nowrap",
+          flexShrink: 0,
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.boxShadow =
+            "0 4px 24px rgba(100,80,255,0.5)";
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.boxShadow =
+            "0 4px 16px rgba(100,80,255,0.3)";
+        }}
+      >
+        Obnovit
+      </button>
+    </div>
+  );
+}

--- a/liquid-glass-clock/hooks/useVersionCheck.ts
+++ b/liquid-glass-clock/hooks/useVersionCheck.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const POLL_INTERVAL_MS = 60_000; // check every 60 seconds
+
+export function useVersionCheck() {
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+
+  useEffect(() => {
+    const currentVersion = process.env.NEXT_PUBLIC_BUILD_ID;
+    if (!currentVersion) return;
+
+    const check = async () => {
+      try {
+        const res = await fetch("/api/version", {
+          cache: "no-store",
+          headers: { "Cache-Control": "no-cache" },
+        });
+        if (!res.ok) return;
+        const data: { version: string } = await res.json();
+        if (data.version && data.version !== currentVersion) {
+          setUpdateAvailable(true);
+        }
+      } catch {
+        // Silently ignore — no network, server down, etc.
+      }
+    };
+
+    const interval = setInterval(check, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  return { updateAvailable };
+}

--- a/liquid-glass-clock/next.config.ts
+++ b/liquid-glass-clock/next.config.ts
@@ -1,7 +1,22 @@
 import type { NextConfig } from "next";
+import { execSync } from "child_process";
+
+function getBuildId(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return Date.now().toString(36);
+  }
+}
+
+const BUILD_ID = getBuildId();
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  generateBuildId: async () => BUILD_ID,
+  env: {
+    NEXT_PUBLIC_BUILD_ID: BUILD_ID,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Hotovo. Tady je přehled toho co bylo implementováno:

**Jak to funguje:**
1. `next.config.ts` — při každém buildu se vygeneruje `BUILD_ID` z git SHA (fallback na timestamp) a zapíše se do client bundlu jako `NEXT_PUBLIC_BUILD_ID`
2. `app/api/version/route.ts` — serverový endpoint, který vrací svůj `BUILD_ID` (vždy z aktuálního deploye)
3. `hooks/useVersionCheck.ts` — každých 60 s porovná klientův vestavěný BUILD_ID s hodnotou z API; pokud se liší, nastaví `updateAvailable = true`
4. `components/UpdateNotification.tsx` — glassmorphism banner (styl shodný s FeedbackWidget) s tlačítkem "Obnovit", který volá `window.location.reload()`

Po novém deployi starý klient detekuje rozdíl verzí a zobrazí banner — žádná manuální aktualizace čísla verze není potřeba.

## Commits

- feat: add automatic new-version detection with refresh notification
- feat: add animated walking sheep (SheepWalker) with béé speech bubble