### PR TITLE
particle na pozadi ted reaguji na mys az prilis.. respektive to uplne prebije jejich vlastni pohyb... jejich pohyb musi 

### DIFF
--- a/liquid-glass-clock/__tests__/GeometricParticles.test.tsx
+++ b/liquid-glass-clock/__tests__/GeometricParticles.test.tsx
@@ -134,4 +134,27 @@ describe("GeometricParticles component", () => {
     // stroke is called for lines
     expect(mockContext.beginPath).toHaveBeenCalled();
   });
+
+  it("handles mousemove event without throwing", () => {
+    render(<GeometricParticles />);
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent("mousemove", { clientX: 100, clientY: 200 })
+      );
+      if (rafCallback) rafCallback(performance.now());
+    });
+    // clearRect should still be called — no crash from mouse handling
+    expect(mockContext.clearRect).toHaveBeenCalled();
+  });
+
+  it("handles mousedown/mouseup (attract mode) without throwing", () => {
+    render(<GeometricParticles />);
+    act(() => {
+      window.dispatchEvent(new MouseEvent("mousemove", { clientX: 50, clientY: 50 }));
+      window.dispatchEvent(new MouseEvent("mousedown"));
+      if (rafCallback) rafCallback(performance.now());
+      window.dispatchEvent(new MouseEvent("mouseup"));
+    });
+    expect(mockContext.clearRect).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Provedené změny:

- **Přidán `MOUSE_RADIUS = 160px`** — myš ovlivňuje pouze částice v tomto okruhu, vzdálenější si udržují vlastní pohyb bez rušení
- **Sníženy síly**: repulze `14→6`, přitahování `7→3` — vliv myši je slabší a vlastní pohyb dominuje
- **Přidán falloff**: síla se plynule vytrácí ke kraji rádiusu, bez ostrého přechodu
- **Zvýšeno tření** `0.99→0.98` — po opuštění okruhu myši se částice rychleji vrátí na přirozenou rychlost

## Commits

- fix: reduce mouse influence on particles so own movement persists
- feat: reverse mouse interaction — attract by default, repel on click; right-click stops sheep