### PR TITLE
KDyz se posila navrh u konkretniho elementu, kdyz se na nej klikne pravym... tak se v message neposila ted informace o t

### DIFF
--- a/liquid-glass-clock/__tests__/ElementSuggestionMenu.test.tsx
+++ b/liquid-glass-clock/__tests__/ElementSuggestionMenu.test.tsx
@@ -199,7 +199,8 @@ describe("ElementSuggestionMenu", () => {
     );
 
     const callBody = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(callBody.message).toBe("Větší font");
+    expect(callBody.message).toMatch(/^\[Element: <p#hero-text>/);
+    expect(callBody.message).toContain("Větší font");
     expect(callBody.type).toBe("element_suggestion");
     expect(callBody.element).toBeDefined();
     expect(callBody.element.tag).toBe("p");

--- a/liquid-glass-clock/components/ElementSuggestionMenu.tsx
+++ b/liquid-glass-clock/components/ElementSuggestionMenu.tsx
@@ -134,8 +134,12 @@ export default function ElementSuggestionMenu() {
 
     setStatus("sending");
 
+    const elementContext = elementInfo
+      ? `[Element: ${getElementDescription(elementInfo)}]\n`
+      : "";
+
     const payload: Record<string, unknown> = {
-      message: trimmed,
+      message: `${elementContext}${trimmed}`,
       type: "element_suggestion",
     };
 


### PR DESCRIPTION
## Summary

V `handleSubmit` v `ElementSuggestionMenu.tsx` je nyní do pole `message` přidán prefix s informací o cílovém elementu ve formátu `[Element: <tag#id> "text"]` před samotnou zprávu uživatele. Webhook tak v poli `message` dostane kompletní kontext jako `[Element: <p#hero-text> "Hello"]\nVětší font`. Test byl upraven a všechny testy prochází.

## Commits

- fix: include element context in message field when submitting suggestion