### PR TITLE
CHci aby se tecky na pozadi jeste odpuzovali sami od sebe jemne

### DIFF
--- a/liquid-glass-clock/__tests__/GeometricParticles.test.tsx
+++ b/liquid-glass-clock/__tests__/GeometricParticles.test.tsx
@@ -135,6 +135,18 @@ describe("GeometricParticles component", () => {
     expect(mockContext.beginPath).toHaveBeenCalled();
   });
 
+  it("applies inter-particle repulsion without throwing over multiple frames", () => {
+    render(<GeometricParticles />);
+    // Run several frames so repulsion forces have a chance to accumulate and be applied
+    act(() => {
+      for (let frame = 0; frame < 5; frame++) {
+        if (rafCallback) rafCallback(performance.now());
+      }
+    });
+    expect(mockContext.clearRect).toHaveBeenCalledTimes(5);
+    expect(mockContext.arc).toHaveBeenCalled();
+  });
+
   it("handles mousemove event without throwing", () => {
     render(<GeometricParticles />);
     act(() => {


### PR DESCRIPTION
## Summary

Dots on the background now also gently repel each other. When two particles come within 60px of each other, an inverse-distance force pushes them apart, fading smoothly to zero at the edge of that radius. Pre-allocated `Float32Array` buffers are reused each frame to keep the O(n²) pair loop GC-friendly.

## Commits

- feat: add gentle inter-particle repulsion to background dots