### PR TITLE
Kdyz jde doleva tak neni otocena doleva ale doprava, oprav

### DIFF
--- a/liquid-glass-clock/__tests__/Sheep.test.tsx
+++ b/liquid-glass-clock/__tests__/Sheep.test.tsx
@@ -168,4 +168,22 @@ describe("Sheep component", () => {
     act(() => { el.dispatchEvent(event); });
     expect(preventDefaultSpy).toHaveBeenCalled();
   });
+
+  it("applies bounce animation and flip transform on separate divs so animation cannot override scaleX(-1)", () => {
+    render(<Sheep />);
+    flushMount();
+    const sheep = screen.getByTestId("sheep");
+    // The bounce class must exist somewhere inside the sheep
+    const bounceDiv = sheep.querySelector(".sheep-running-bounce");
+    expect(bounceDiv).not.toBeNull();
+    // The bounce div must NOT be the same element that carries the flip transform.
+    // The flip div is the direct parent of the bounce div.
+    const flipDiv = bounceDiv?.parentElement;
+    expect(flipDiv).not.toBeNull();
+    expect(flipDiv).not.toHaveClass("sheep-running-bounce");
+    // Initially facing right → flip div has no scaleX transform
+    expect(flipDiv).not.toHaveStyle({ transform: "scaleX(-1)" });
+    // The bounce div itself also must not carry a scaleX flip
+    expect(bounceDiv).not.toHaveStyle({ transform: "scaleX(-1)" });
+  });
 });


### PR DESCRIPTION
## Summary

Příčina bugu: v `Sheep.tsx` byly CSS animace (`sheep-running-bounce`) a inline styl `transform: scaleX(-1)` na **stejném** `<div>` elementu. Podle CSS specifikace mají animace vyšší prioritu v kaskádě než inline styly — animace tedy přepisovala flip transform, takže ovce při pohybu doleva zůstávala otočená doprava.

Oprava: oddělení flip divu a bounce divu do dvou zanořených elementů (stejný vzor jako v `SheepWalker`). Přidán regresní test, který ověřuje, že oba transform jsou vždy na samostatných elementech.

## Commits

- fix: separate flip transform and bounce animation into nested divs in Sheep
- feat: add gentle inter-particle repulsion to background dots
- fix: include element context in message field when submitting suggestion
- feat: sheep now walk on all four screen edges with corner turning
- fix: reduce mouse influence on particles so own movement persists