### PR TITLE
Pridej dvakrat vic tecek na pozadi... audelej aby byli dvakrat vice reaktivnejsi vuci mysi

### DIFF
--- a/liquid-glass-clock/components/GeometricParticles.tsx
+++ b/liquid-glass-clock/components/GeometricParticles.tsx
@@ -25,14 +25,14 @@ const DOT_COLORS = [
   { dot: "rgba(255, 255, 255, 0.75)", glow: "rgba(255, 255, 255, 0.25)" },
 ];
 
-const PARTICLE_COUNT = 180;
+const PARTICLE_COUNT = 360;
 const CONNECTION_DISTANCE = 120;
 const MAX_LINE_OPACITY = 0.45;
 const SPEED = 0.4;
 const MAX_SPEED = 3;
-const MOUSE_RADIUS = 160;
-const GRAVITY_K_ATTRACT = 3;
-const GRAVITY_K_REPEL = 6;
+const MOUSE_RADIUS = 320;
+const GRAVITY_K_ATTRACT = 6;
+const GRAVITY_K_REPEL = 12;
 const MIN_DIST = 20;
 const PARTICLE_REPEL_RADIUS = 60;
 const PARTICLE_REPEL_K = 0.8;


### PR DESCRIPTION
## Summary

`PARTICLE_COUNT` was doubled from 180 to 360, giving twice as many background dots. Mouse reactivity was also doubled — `MOUSE_RADIUS` went from 160→320, `GRAVITY_K_ATTRACT` from 3→6, and `GRAVITY_K_REPEL` from 6→12, meaning particles respond to the cursor over a larger area with twice the force.

## Commits

- feat: double particle count and mouse reactivity in GeometricParticles