### PR TITLE
Pridej k tomu tlacitku v rohu, kde se pridava navrh k implementaci... aby se vedle neho take ukazovalo pocet bezicich ta

### DIFF
--- a/liquid-glass-clock/__tests__/FeedbackWidget.test.tsx
+++ b/liquid-glass-clock/__tests__/FeedbackWidget.test.tsx
@@ -15,27 +15,37 @@ describe("FeedbackWidget", () => {
   beforeEach(() => {
     fetchMock = jest.fn();
     global.fetch = fetchMock;
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
-  it("renders the toggle button", () => {
+  // Helper: default GET response (no tasks)
+  const mockGetEmpty = () =>
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => [] });
+
+  it("renders the toggle button", async () => {
+    mockGetEmpty();
     render(<FeedbackWidget />);
     expect(
       screen.getByRole("button", { name: /otevřít panel nápadů/i })
     ).toBeInTheDocument();
   });
 
-  it("opens the chat panel when the button is clicked", () => {
+  it("opens the chat panel when the button is clicked", async () => {
+    mockGetEmpty();
     render(<FeedbackWidget />);
     const toggleBtn = screen.getByRole("button", { name: /otevřít panel nápadů/i });
     fireEvent.click(toggleBtn);
     expect(screen.getByPlaceholderText(/co by se tu mělo/i)).toBeInTheDocument();
   });
 
-  it("closes the chat panel when toggle button is clicked again", () => {
+  it("closes the chat panel when toggle button is clicked again", async () => {
+    mockGetEmpty();
     render(<FeedbackWidget />);
     const toggleBtn = screen.getByRole("button", { name: /otevřít panel nápadů/i });
     fireEvent.click(toggleBtn);
@@ -46,22 +56,24 @@ describe("FeedbackWidget", () => {
     expect(screen.queryByPlaceholderText(/co by se tu mělo/i)).not.toBeInTheDocument();
   });
 
-  it("closes the panel with the × header button", () => {
+  it("closes the panel with the × header button", async () => {
+    mockGetEmpty();
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
-    // Click the header × button (exact aria-label "Zavřít")
     fireEvent.click(screen.getByRole("button", { name: "Zavřít" }));
     expect(screen.queryByPlaceholderText(/co by se tu mělo/i)).not.toBeInTheDocument();
   });
 
-  it("submit button is disabled when textarea is empty", () => {
+  it("submit button is disabled when textarea is empty", async () => {
+    mockGetEmpty();
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
     const submitBtn = screen.getByRole("button", { name: /odeslat nápad/i });
     expect(submitBtn).toBeDisabled();
   });
 
-  it("submit button becomes enabled when text is entered", () => {
+  it("submit button becomes enabled when text is entered", async () => {
+    mockGetEmpty();
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
     const textarea = screen.getByPlaceholderText(/co by se tu mělo/i);
@@ -71,7 +83,10 @@ describe("FeedbackWidget", () => {
   });
 
   it("sends POST request to webhook URL on submit", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+    // First call is GET (task counts), subsequent call is POST
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
 
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
@@ -82,18 +97,22 @@ describe("FeedbackWidget", () => {
       fireEvent.click(screen.getByRole("button", { name: /odeslat nápad/i }));
     });
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      WEBHOOK_URL,
-      expect.objectContaining({
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: "Přidat tmavý režim" }),
-      })
+    const postCall = fetchMock.mock.calls.find(
+      ([, opts]: [string, RequestInit]) => opts?.method === "POST"
     );
+    expect(postCall).toBeDefined();
+    expect(postCall[0]).toBe(WEBHOOK_URL);
+    expect(postCall[1]).toMatchObject({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Přidat tmavý režim" }),
+    });
   });
 
   it("shows success message after successful submission", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
 
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
@@ -111,7 +130,9 @@ describe("FeedbackWidget", () => {
   });
 
   it("shows error message when fetch fails", async () => {
-    fetchMock.mockRejectedValueOnce(new Error("Network error"));
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })
+      .mockRejectedValueOnce(new Error("Network error"));
 
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
@@ -127,7 +148,9 @@ describe("FeedbackWidget", () => {
   });
 
   it("shows error message when server returns non-ok response", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
 
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
@@ -143,7 +166,9 @@ describe("FeedbackWidget", () => {
   });
 
   it("submits on Enter key press", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
 
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
@@ -154,10 +179,14 @@ describe("FeedbackWidget", () => {
       fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const postCalls = fetchMock.mock.calls.filter(
+      ([, opts]: [string, RequestInit]) => opts?.method === "POST"
+    );
+    expect(postCalls).toHaveLength(1);
   });
 
   it("does NOT submit on Shift+Enter key press", async () => {
+    mockGetEmpty();
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
     const textarea = screen.getByPlaceholderText(/co by se tu mělo/i);
@@ -165,22 +194,27 @@ describe("FeedbackWidget", () => {
 
     fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    const postCalls = fetchMock.mock.calls.filter(
+      ([, opts]: [string, RequestInit]) => opts?.method === "POST"
+    );
+    expect(postCalls).toHaveLength(0);
   });
 
   it("trims whitespace-only messages and does not submit", async () => {
+    mockGetEmpty();
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
     fireEvent.change(screen.getByPlaceholderText(/co by se tu mělo/i), {
       target: { value: "   " },
     });
-    // Button should remain disabled for whitespace-only input
     const submitBtn = screen.getByRole("button", { name: /odeslat nápad/i });
     expect(submitBtn).toBeDisabled();
   });
 
   it("allows sending another message after clicking 'Odeslat další'", async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
 
     render(<FeedbackWidget />);
     fireEvent.click(screen.getByRole("button", { name: /otevřít panel nápadů/i }));
@@ -197,5 +231,161 @@ describe("FeedbackWidget", () => {
     fireEvent.click(screen.getByRole("button", { name: /odeslat další/i }));
 
     expect(screen.getByPlaceholderText(/co by se tu mělo/i)).toBeInTheDocument();
+  });
+
+  // ─── Task counts ───────────────────────────────────────────────────────────
+
+  it("does not show task-counts badge when GET returns empty array", async () => {
+    mockGetEmpty();
+    await act(async () => {
+      render(<FeedbackWidget />);
+    });
+    expect(screen.queryByTestId("task-counts")).not.toBeInTheDocument();
+  });
+
+  it("shows running count when GET returns running tasks", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { id: "1", status: "running" },
+        { id: "2", status: "running" },
+      ],
+    });
+
+    await act(async () => {
+      render(<FeedbackWidget />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-counts")).toBeInTheDocument();
+      expect(screen.getByTestId("running-count")).toHaveTextContent("2");
+    });
+  });
+
+  it("shows queued count when GET returns queued tasks", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { id: "1", status: "queued" },
+        { id: "2", status: "queued" },
+        { id: "3", status: "queued" },
+      ],
+    });
+
+    await act(async () => {
+      render(<FeedbackWidget />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-counts")).toBeInTheDocument();
+      expect(screen.getByTestId("queued-count")).toHaveTextContent("3");
+    });
+  });
+
+  it("shows both running and queued counts when mixed tasks returned", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { id: "1", status: "running" },
+        { id: "2", status: "queued" },
+        { id: "3", status: "queued" },
+        { id: "4", status: "done" },
+      ],
+    });
+
+    await act(async () => {
+      render(<FeedbackWidget />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("running-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("queued-count")).toHaveTextContent("2");
+    });
+  });
+
+  it("handles GET returning tasks wrapped in object with tasks key", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        tasks: [
+          { id: "1", status: "running" },
+          { id: "2", status: "queued" },
+        ],
+      }),
+    });
+
+    await act(async () => {
+      render(<FeedbackWidget />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("running-count")).toHaveTextContent("1");
+      expect(screen.getByTestId("queued-count")).toHaveTextContent("1");
+    });
+  });
+
+  it("does not show badge when GET fails", async () => {
+    fetchMock.mockRejectedValue(new Error("Network error"));
+
+    await act(async () => {
+      render(<FeedbackWidget />);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("task-counts")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not show badge when GET returns non-ok response", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503, json: async () => ({}) });
+
+    await act(async () => {
+      render(<FeedbackWidget />);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("task-counts")).not.toBeInTheDocument();
+    });
+  });
+
+  it("makes GET request to the same WEBHOOK_URL", async () => {
+    mockGetEmpty();
+
+    await act(async () => {
+      render(<FeedbackWidget />);
+    });
+
+    const getCall = fetchMock.mock.calls.find(
+      ([, opts]: [string, RequestInit | undefined]) =>
+        !opts || opts.method === "GET" || opts.method === undefined
+    );
+    expect(getCall).toBeDefined();
+    expect(getCall[0]).toBe(WEBHOOK_URL);
+  });
+
+  it("re-polls after interval elapses", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    });
+
+    await act(async () => {
+      render(<FeedbackWidget />);
+    });
+
+    // Initial fetch
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Advance past the 30s polling interval
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary

The background task confirmed the same findings — `demo-web-1-get-queue` and `demo-web-1-task-queue` timed out (error 524 = Cloudflare gateway timeout), while `demo-web-1-stats` returned 404 (not registered).

This aligns with the implementation I already shipped: the GET endpoint at the same webhook URL isn't active yet on the n8n side. The code is ready and will work as soon as the n8n workflow is configured to handle GET requests — it polls the same `demo-web-1-create-issue` URL and gracefully shows nothing when the endpoint isn't reachable.

## Commits

- feat: add running/queued task count badge next to feedback button