### PR TITLE
Pridej koliddery na ty stavebny bloky, na domy, na stromy a objekty, ktere by to meli mit

### DIFF
--- a/liquid-glass-clock/__tests__/meshBuilders.test.ts
+++ b/liquid-glass-clock/__tests__/meshBuilders.test.ts
@@ -162,6 +162,74 @@ describe("buildTreeMesh", () => {
       expect(result.foliageGroup).toBeInstanceOf(THREE.Group);
     }
   });
+
+  it("large pine trees (trunkH > 5.0) have hasCollision true", () => {
+    // Seed 1 produces a pine tree — run many seeds and verify at least one large pine
+    let foundLargePine = false;
+    for (let seed = 0; seed < 200; seed++) {
+      const rng = makeRng(seed * 3 + 1);
+      const typeRoll = rng(); // consume first rng for type selection
+      if (typeRoll < 0.30) {
+        // This is a pine — trunkH = 4.5 + rng() * 4.0 on next call
+        // Reset and re-run buildTreeMesh to get actual result
+        const rng2 = makeRng(seed * 3 + 1);
+        const result = buildTreeMesh(rng2);
+        if (result.hasCollision) {
+          foundLargePine = true;
+          break;
+        }
+      }
+    }
+    expect(foundLargePine).toBe(true);
+  });
+
+  it("birch trees with trunkH > 4.5 have hasCollision true", () => {
+    // Find a seed that produces a large birch
+    let foundLargeBirch = false;
+    for (let seed = 0; seed < 500; seed++) {
+      const rng = makeRng(seed * 11 + 7);
+      const result = buildTreeMesh(rng);
+      // If group has no foliage blobs (dead tree) or has cones (pine), skip
+      // We detect birch by checking foliage children exist AND hasCollision
+      // Just check that across seeds we get some birch with hasCollision=true
+      if (result.foliageGroup.children.length > 0 && result.hasCollision && result.trunkRadius < 0.13) {
+        // Birch has slim trunks (0.07–0.12) and foliage
+        foundLargeBirch = true;
+        break;
+      }
+    }
+    expect(foundLargeBirch).toBe(true);
+  });
+
+  it("dead trees with trunkH > 4.5 have hasCollision true", () => {
+    // Find a seed producing a large dead tree
+    let foundLargeDeadTree = false;
+    for (let seed = 0; seed < 500; seed++) {
+      const rng = makeRng(seed * 17 + 3);
+      const result = buildTreeMesh(rng);
+      // Dead trees have empty foliageGroup — detect by 0 foliage children
+      if (result.foliageGroup.children.length === 0 && result.hasCollision) {
+        foundLargeDeadTree = true;
+        break;
+      }
+    }
+    expect(foundLargeDeadTree).toBe(true);
+  });
+
+  it("small birch trees (trunkH <= 4.5) have hasCollision false", () => {
+    // Verify that not all birch trees get collision (only large ones do)
+    let foundSmallBirch = false;
+    for (let seed = 0; seed < 500; seed++) {
+      const rng = makeRng(seed * 13 + 5);
+      const result = buildTreeMesh(rng);
+      // Slim-trunk tree with foliage and NO collision = small birch
+      if (result.foliageGroup.children.length > 0 && !result.hasCollision && result.trunkRadius < 0.13) {
+        foundSmallBirch = true;
+        break;
+      }
+    }
+    expect(foundSmallBirch).toBe(true);
+  });
 });
 
 describe("buildBushMesh", () => {
@@ -204,17 +272,34 @@ describe("buildBushMesh", () => {
 });
 
 describe("buildRockMesh", () => {
-  it("returns a THREE.Mesh", () => {
+  it("returns { mesh, collisionRadius }", () => {
     const rng = makeRng(42);
-    const mesh = buildRockMesh(rng);
-    expect(mesh).toBeInstanceOf(THREE.Mesh);
+    const result = buildRockMesh(rng);
+    expect(result.mesh).toBeInstanceOf(THREE.Mesh);
+    expect(typeof result.collisionRadius).toBe("number");
+    expect(result.collisionRadius).toBeGreaterThan(0);
   });
 
-  it("has castShadow and receiveShadow", () => {
+  it("mesh has castShadow and receiveShadow", () => {
     const rng = makeRng(42);
-    const mesh = buildRockMesh(rng);
+    const { mesh } = buildRockMesh(rng);
     expect(mesh.castShadow).toBe(true);
     expect(mesh.receiveShadow).toBe(true);
+  });
+
+  it("collisionRadius equals baseRadius * max(scaleX, scaleZ)", () => {
+    // With seed 42: first rng → baseRadius, then scaleX, scaleY, scaleZ
+    // collisionRadius must be positive and <= (0.8) * 1.5 = 1.2
+    const rng = makeRng(42);
+    const { collisionRadius } = buildRockMesh(rng);
+    expect(collisionRadius).toBeGreaterThan(0);
+    expect(collisionRadius).toBeLessThanOrEqual(1.2);
+  });
+
+  it("produces different rocks for different seeds", () => {
+    const r1 = buildRockMesh(makeRng(10));
+    const r2 = buildRockMesh(makeRng(99));
+    expect(r1.collisionRadius).not.toBeCloseTo(r2.collisionRadius, 5);
   });
 });
 
@@ -281,25 +366,51 @@ describe("buildHouse", () => {
 });
 
 describe("buildRuins", () => {
-  it("returns a THREE.Group", () => {
+  it("returns { group, boxColliders, cylColliders }", () => {
     const rng = makeRng(1);
-    const ruins = buildRuins(rng);
-    expect(ruins).toBeInstanceOf(THREE.Group);
+    const result = buildRuins(rng);
+    expect(result.group).toBeInstanceOf(THREE.Group);
+    expect(Array.isArray(result.boxColliders)).toBe(true);
+    expect(Array.isArray(result.cylColliders)).toBe(true);
   });
 
   it("has walls, columns, and debris", () => {
     const rng = makeRng(1);
-    const ruins = buildRuins(rng);
-    expect(ruins.children.length).toBeGreaterThan(5);
+    const { group } = buildRuins(rng);
+    expect(group.children.length).toBeGreaterThan(5);
   });
 
   it("all mesh children have castShadow", () => {
     const rng = makeRng(1);
-    const ruins = buildRuins(rng);
-    ruins.children.forEach((child) => {
+    const { group } = buildRuins(rng);
+    group.children.forEach((child) => {
       if (child instanceof THREE.Mesh) {
         expect(child.castShadow).toBe(true);
       }
+    });
+  });
+
+  it("boxColliders has entries for both walls", () => {
+    const rng = makeRng(1);
+    const { boxColliders } = buildRuins(rng);
+    // Two walls: w1 (front) and w2 (side)
+    expect(boxColliders.length).toBeGreaterThanOrEqual(2);
+    boxColliders.forEach((bc) => {
+      expect(typeof bc.halfW).toBe("number");
+      expect(typeof bc.halfD).toBe("number");
+      expect(bc.halfW).toBeGreaterThan(0);
+      expect(bc.halfD).toBeGreaterThan(0);
+    });
+  });
+
+  it("cylColliders has entries for arch bases and columns", () => {
+    const rng = makeRng(1);
+    const { cylColliders } = buildRuins(rng);
+    // 2 arch bases + 3 columns = 5 cylinder colliders
+    expect(cylColliders.length).toBe(5);
+    cylColliders.forEach((cc) => {
+      expect(typeof cc.radius).toBe("number");
+      expect(cc.radius).toBeGreaterThan(0);
     });
   });
 });

--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -56,6 +56,7 @@ import {
   buildSwordMesh,
   buildSniperMesh,
   type SheepMeshParts,
+  type RuinsResult,
 } from "@/lib/meshBuilders";
 import type { SheepData, FoxData, CoinData, BulletData, GameState, WeaponType } from "@/lib/gameTypes";
 import { WEAPON_CONFIGS } from "@/lib/gameTypes";
@@ -425,6 +426,13 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
   const treeCollisionRef = useRef<Array<{
     x: number; z: number;
     radius: number;        // trunk radius + small buffer
+  }>>([]);
+  /** Box colliders for landmarks (house, ruins walls).
+   *  halfW / halfD are local half-extents; rotY is the world-space rotation. */
+  const boxCollidersRef = useRef<Array<{
+    cx: number; cz: number;
+    halfW: number; halfD: number;
+    rotY: number;
   }>>([]);
 
   // ─── Combat Refs ────────────────────────────────────────────────────────────
@@ -2045,10 +2053,12 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     };
     const rockPoints = generateSpawnPoints(ROCK_COUNT, 15, 380, 456);
     rockPoints.forEach((p) => {
-      const rock = buildRockMesh(rockRng);
+      const { mesh: rock, collisionRadius: rockCollRadius } = buildRockMesh(rockRng);
       rock.position.set(p.x, p.y + 0.2, p.z);
       rock.rotation.y = rockRng() * Math.PI * 2;
       scene.add(rock);
+      // All rocks block the player — even small ones are solid obstacles
+      treeCollisionRef.current.push({ x: p.x, z: p.z, radius: rockCollRadius + PLAYER_RADIUS });
     });
 
     // ── Sheep ────────────────────────────────────────────────────────────────
@@ -2159,6 +2169,8 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     windmillGroup.position.set(windmillX, getTerrainHeightSampled(windmillX, windmillZ), windmillZ);
     scene.add(windmillGroup);
     windmillBladesRef.current = blades;
+    // Cylinder collider for the windmill tower (base radius 1.1)
+    treeCollisionRef.current.push({ x: windmillX, z: windmillZ, radius: 1.1 + PLAYER_RADIUS });
 
     // ── Farmhouse (near the pen) ──────────────────────────────────────────────
     let houseSeed = 88;
@@ -2172,6 +2184,8 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     house.position.set(houseX, getTerrainHeightSampled(houseX, houseZ), houseZ);
     house.rotation.y = Math.PI * 0.15;
     scene.add(house);
+    // Box collider for the house walls (7×5.5 footprint, same rotation as the mesh)
+    boxCollidersRef.current.push({ cx: houseX, cz: houseZ, halfW: 3.5, halfD: 2.75, rotY: Math.PI * 0.15 });
 
     // ── Ruins (distant location) ──────────────────────────────────────────────
     let ruinsSeed = 999;
@@ -2179,12 +2193,34 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
       ruinsSeed = (ruinsSeed * 1664525 + 1013904223) & 0xffffffff;
       return (ruinsSeed >>> 0) / 0xffffffff;
     };
-    const ruins = buildRuins(ruinsRng);
+    const { group: ruins, boxColliders: ruinsBoxes, cylColliders: ruinsCyls }: RuinsResult = buildRuins(ruinsRng);
     const ruinsX = 180;
     const ruinsZ = -120;
+    const ruinsRotY = 0.4;
     ruins.position.set(ruinsX, getTerrainHeightSampled(ruinsX, ruinsZ), ruinsZ);
-    ruins.rotation.y = 0.4;
+    ruins.rotation.y = ruinsRotY;
     scene.add(ruins);
+    // Register ruins box colliders in world space (rotate local positions by ruinsRotY)
+    {
+      const cosR = Math.cos(ruinsRotY);
+      const sinR = Math.sin(ruinsRotY);
+      for (const bc of ruinsBoxes) {
+        boxCollidersRef.current.push({
+          cx: ruinsX + bc.lx * cosR - bc.lz * sinR,
+          cz: ruinsZ + bc.lx * sinR + bc.lz * cosR,
+          halfW: bc.halfW,
+          halfD: bc.halfD,
+          rotY: bc.rotY + ruinsRotY,
+        });
+      }
+      for (const cc of ruinsCyls) {
+        treeCollisionRef.current.push({
+          x: ruinsX + cc.lx * cosR - cc.lz * sinR,
+          z: ruinsZ + cc.lx * sinR + cc.lz * cosR,
+          radius: cc.radius + PLAYER_RADIUS,
+        });
+      }
+    }
 
     // ── Lighthouse (on a coastal rise) ───────────────────────────────────────
     const { group: lighthouse, beamPivot, lighthouseLight } = buildLighthouse();
@@ -2194,6 +2230,8 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     scene.add(lighthouse);
     lighthouseBeamRef.current = beamPivot;
     lighthouseLightRef.current = lighthouseLight;
+    // Cylinder collider for the lighthouse base (base radius 2.2)
+    treeCollisionRef.current.push({ x: lhX, z: lhZ, radius: 2.2 + PLAYER_RADIUS });
 
     // ── Input ─────────────────────────────────────────────────────────────────
     // ── Mouse click — attack OR build depending on current mode ───────────────
@@ -2785,6 +2823,57 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
           }
         }
 
+        // Box colliders: houses, ruins walls — OBB push-out in 2D
+        for (const box of boxCollidersRef.current) {
+          const cosR = Math.cos(box.rotY);
+          const sinR = Math.sin(box.rotY);
+          const dx = cam.position.x - box.cx;
+          const dz = cam.position.z - box.cz;
+          // Transform to box-local space (rotate by -rotY)
+          const lx = dx * cosR + dz * sinR;
+          const lz = -dx * sinR + dz * cosR;
+          const inflW = box.halfW + PLAYER_RADIUS;
+          const inflD = box.halfD + PLAYER_RADIUS;
+          if (Math.abs(lx) < inflW && Math.abs(lz) < inflD) {
+            // Push out along the axis of least penetration
+            const overlapX = inflW - Math.abs(lx);
+            const overlapZ = inflD - Math.abs(lz);
+            let pushLx = 0, pushLz = 0;
+            if (overlapX < overlapZ) {
+              pushLx = overlapX * Math.sign(lx);
+            } else {
+              pushLz = overlapZ * Math.sign(lz);
+            }
+            const newLx = lx + pushLx;
+            const newLz = lz + pushLz;
+            // Rotate back to world space
+            cam.position.x = box.cx + newLx * cosR - newLz * sinR;
+            cam.position.z = box.cz + newLx * sinR + newLz * cosR;
+          }
+        }
+
+        // Building block horizontal collision — AABB per block
+        for (const block of placedBlocksDataRef.current) {
+          const bdx = cam.position.x - block.x;
+          const bdz = cam.position.z - block.z;
+          if (Math.abs(bdx) > 1.5 || Math.abs(bdz) > 1.5) continue; // quick distance cull
+          const playerFeetY = cam.position.y - PLAYER_HEIGHT;
+          const blockTop = block.y + 0.5;
+          const blockBottom = block.y - 0.5;
+          // Only apply horizontal push when player height overlaps with block
+          if (playerFeetY >= blockTop || cam.position.y <= blockBottom) continue;
+          const inflH = 0.5 + PLAYER_RADIUS;
+          if (Math.abs(bdx) < inflH && Math.abs(bdz) < inflH) {
+            const overlapX = inflH - Math.abs(bdx);
+            const overlapZ = inflH - Math.abs(bdz);
+            if (overlapX < overlapZ) {
+              cam.position.x += overlapX * Math.sign(bdx);
+            } else {
+              cam.position.z += overlapZ * Math.sign(bdz);
+            }
+          }
+        }
+
         const player = playerRef.current;
         if (keys["Space"] && player.onGround) {
           player.velY = JUMP_FORCE;
@@ -2794,7 +2883,16 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         player.velY += GRAVITY * dt;
         cam.position.y += player.velY * dt;
 
-        const groundY = getTerrainHeightSampled(cam.position.x, cam.position.z) + PLAYER_HEIGHT;
+        // Ground detection: terrain height or top of placed blocks
+        let groundY = getTerrainHeightSampled(cam.position.x, cam.position.z) + PLAYER_HEIGHT;
+        for (const block of placedBlocksDataRef.current) {
+          const bdx = Math.abs(cam.position.x - block.x);
+          const bdz = Math.abs(cam.position.z - block.z);
+          if (bdx <= 0.5 && bdz <= 0.5) {
+            const blockGroundY = block.y + 0.5 + PLAYER_HEIGHT;
+            if (blockGroundY > groundY) groundY = blockGroundY;
+          }
+        }
         if (cam.position.y <= groundY) {
           cam.position.y = groundY;
           player.velY = 0;

--- a/liquid-glass-clock/lib/meshBuilders.ts
+++ b/liquid-glass-clock/lib/meshBuilders.ts
@@ -249,7 +249,7 @@ export function buildTreeMesh(rng: () => number): TreeMeshResult {
     // ── Pine / Conifer ──────────────────────────────────────────────────────
     const trunkH = 4.5 + rng() * 4.0;   // 4.5–8.5 — tall and narrow
     const trunkR = 0.11 + rng() * 0.08;
-    const isLarge = trunkH > 6.0;
+    const isLarge = trunkH > 5.0;
 
     const trunkMat = new THREE.MeshLambertMaterial({ color: 0x3a2010 });
     const trunkGeo = new THREE.CylinderGeometry(trunkR * 0.45, trunkR, trunkH, 7);
@@ -288,7 +288,7 @@ export function buildTreeMesh(rng: () => number): TreeMeshResult {
     // ── Oak / Deciduous ─────────────────────────────────────────────────────
     const trunkH = 2.8 + rng() * 2.5;   // 2.8–5.3
     const trunkR = 0.18 + rng() * 0.14; // 0.18–0.32
-    const isLarge = trunkH > 3.8;
+    const isLarge = trunkH > 3.2;
 
     const trunkMat = new THREE.MeshLambertMaterial({ color: 0x4a2a10 });
     const trunkGeo = new THREE.CylinderGeometry(trunkR * 0.65, trunkR * 1.1, trunkH, 8);
@@ -345,6 +345,7 @@ export function buildTreeMesh(rng: () => number): TreeMeshResult {
     // ── Birch ───────────────────────────────────────────────────────────────
     const trunkH = 3.2 + rng() * 2.5;   // 3.2–5.7  slender and tall
     const trunkR = 0.07 + rng() * 0.05; // slim trunk
+    const isLarge = trunkH > 4.5;
 
     // White/cream bark
     const trunkMat = new THREE.MeshLambertMaterial({ color: 0xe0d8c8 });
@@ -392,12 +393,13 @@ export function buildTreeMesh(rng: () => number): TreeMeshResult {
       foliageGroup.add(blob);
     }
     group.add(foliageGroup);
-    return { group, foliageGroup, trunkRadius: trunkR, hasCollision: false };
+    return { group, foliageGroup, trunkRadius: trunkR, hasCollision: isLarge };
 
   } else {
     // ── Dead / Bare tree ────────────────────────────────────────────────────
     const trunkH = 3.0 + rng() * 3.5;
     const trunkR = 0.10 + rng() * 0.09;
+    const isLargeDead = trunkH > 4.5;
 
     const trunkMat = new THREE.MeshLambertMaterial({ color: 0x252015 });
     const trunkGeo = new THREE.CylinderGeometry(trunkR * 0.4, trunkR, trunkH, 6);
@@ -427,7 +429,7 @@ export function buildTreeMesh(rng: () => number): TreeMeshResult {
     }
     // Dead trees: no foliage — foliageGroup stays empty
     group.add(foliageGroup);
-    return { group, foliageGroup, trunkRadius: trunkR, hasCollision: false };
+    return { group, foliageGroup, trunkRadius: trunkR, hasCollision: isLargeDead };
   }
 }
 
@@ -492,16 +494,27 @@ export function buildBushMesh(rng: () => number): BushMeshResult {
 }
 
 // ─── Rock ─────────────────────────────────────────────────────────────────────
-export function buildRockMesh(rng: () => number): THREE.Mesh {
-  const geo = new THREE.DodecahedronGeometry(0.3 + rng() * 0.5, 0);
-  geo.scale(1 + rng() * 0.5, 0.6 + rng() * 0.5, 1 + rng() * 0.5);
+export interface RockMeshResult {
+  mesh: THREE.Mesh;
+  /** Maximum horizontal radius of this rock, for cylinder collision detection. */
+  collisionRadius: number;
+}
+
+export function buildRockMesh(rng: () => number): RockMeshResult {
+  const baseRadius = 0.3 + rng() * 0.5;
+  const scaleX = 1 + rng() * 0.5;
+  const scaleY = 0.6 + rng() * 0.5;
+  const scaleZ = 1 + rng() * 0.5;
+  const geo = new THREE.DodecahedronGeometry(baseRadius, 0);
+  geo.scale(scaleX, scaleY, scaleZ);
   const mat = new THREE.MeshLambertMaterial({
     color: new THREE.Color(0.45 + rng() * 0.1, 0.42 + rng() * 0.1, 0.4 + rng() * 0.1),
   });
   const mesh = new THREE.Mesh(geo, mat);
   mesh.castShadow = true;
   mesh.receiveShadow = true;
-  return mesh;
+  const collisionRadius = baseRadius * Math.max(scaleX, scaleZ);
+  return { mesh, collisionRadius };
 }
 
 // ─── Coin ─────────────────────────────────────────────────────────────────────
@@ -624,10 +637,31 @@ export function buildHouse(rng: () => number): THREE.Group {
 }
 
 // ─── Ancient Ruins ────────────────────────────────────────────────────────────
-export function buildRuins(rng: () => number): THREE.Group {
+
+/** Local-space box collider (relative to ruins group origin). */
+export interface RuinsBoxCollider {
+  lx: number; lz: number;
+  halfW: number; halfD: number;
+  rotY: number;
+}
+/** Local-space cylinder collider (relative to ruins group origin). */
+export interface RuinsCylCollider {
+  lx: number; lz: number;
+  radius: number;
+}
+export interface RuinsResult {
+  group: THREE.Group;
+  boxColliders: RuinsBoxCollider[];
+  cylColliders: RuinsCylCollider[];
+}
+
+export function buildRuins(rng: () => number): RuinsResult {
   const group = new THREE.Group();
   const stoneMat = new THREE.MeshLambertMaterial({ color: 0x999088 });
   const darkStoneMat = new THREE.MeshLambertMaterial({ color: 0x6a6058 });
+
+  const boxColliders: RuinsBoxCollider[] = [];
+  const cylColliders: RuinsCylCollider[] = [];
 
   // Broken walls
   const w1H = 2.5 + rng() * 2;
@@ -636,6 +670,7 @@ export function buildRuins(rng: () => number): THREE.Group {
   w1.rotation.y = (rng() - 0.5) * 0.15;
   w1.castShadow = true;
   group.add(w1);
+  boxColliders.push({ lx: 0, lz: 0, halfW: 4, halfD: 0.35, rotY: w1.rotation.y });
 
   // Side wall (partial)
   const w2H = 1.8 + rng() * 1.5;
@@ -643,17 +678,20 @@ export function buildRuins(rng: () => number): THREE.Group {
   w2.position.set(4, w2H / 2, -3);
   w2.castShadow = true;
   group.add(w2);
+  boxColliders.push({ lx: 4, lz: -3, halfW: 0.35, halfD: 3, rotY: 0 });
 
   // Arch remnant
   const archBaseL = new THREE.Mesh(new THREE.BoxGeometry(0.8, 3.5, 0.8), darkStoneMat);
   archBaseL.position.set(-2, 1.75, 0.1);
   archBaseL.castShadow = true;
   group.add(archBaseL);
+  cylColliders.push({ lx: -2, lz: 0.1, radius: 0.6 });
 
   const archBaseR = new THREE.Mesh(new THREE.BoxGeometry(0.8, 3.5, 0.8), darkStoneMat);
   archBaseR.position.set(2, 1.75, 0.1);
   archBaseR.castShadow = true;
   group.add(archBaseR);
+  cylColliders.push({ lx: 2, lz: 0.1, radius: 0.6 });
 
   const archTop = new THREE.Mesh(new THREE.BoxGeometry(5, 0.8, 0.8), darkStoneMat);
   archTop.position.set(0, 3.9, 0.1);
@@ -665,10 +703,13 @@ export function buildRuins(rng: () => number): THREE.Group {
     const colH = 2 + rng() * 3;
     const colGeo = new THREE.CylinderGeometry(0.35, 0.4, colH, 8);
     const col = new THREE.Mesh(colGeo, stoneMat);
-    col.position.set(-6 + i * 3 + rng() * 0.5, colH / 2, 4 + (rng() - 0.5) * 2);
+    const colX = -6 + i * 3 + rng() * 0.5;
+    const colZ = 4 + (rng() - 0.5) * 2;
+    col.position.set(colX, colH / 2, colZ);
     col.rotation.z = (rng() - 0.5) * 0.12;
     col.castShadow = true;
     group.add(col);
+    cylColliders.push({ lx: colX, lz: colZ, radius: 0.5 });
     // Capital
     const capGeo = new THREE.BoxGeometry(0.9, 0.3, 0.9);
     const capMesh = new THREE.Mesh(capGeo, darkStoneMat);
@@ -692,7 +733,7 @@ export function buildRuins(rng: () => number): THREE.Group {
     group.add(debris);
   }
 
-  return group;
+  return { group, boxColliders, cylColliders };
 }
 
 // ─── Bullet ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The Game3D test OOM crash is a pre-existing issue — the test mounts the full 3D world (180 trees, 220 bushes, 90 rocks, water shader, grass, etc.) which exceeds the default Node.js heap. This is unrelated to our collision changes.

All changes are committed and working correctly. The relevant tests (meshBuilders, buildingSystem, terrainUtils) pass with 124 tests ✓.

## Commits

- feat: add colliders to all trees, rocks, and buildings
- Merge pull request #171 from pepavlin/impl/task-mNINcAvI
- feat: add first/third-person camera toggle with [V] key
- feat: weapon selection by 1/2/3 keys and mouse wheel, 3-slot weapon HUD