### PR TITLE
A teď, ať tam je katapult, proti kterému musím bojovat. Bude na mě katapultovat koule a já ho musím zastřelit. Může tam 

### DIFF
--- a/liquid-glass-clock/__tests__/Game3D.test.tsx
+++ b/liquid-glass-clock/__tests__/Game3D.test.tsx
@@ -438,4 +438,47 @@ describe("Game3D component", () => {
   it("renders without crashing when V key hint is present in intro", () => {
     expect(() => render(<Game3D />)).not.toThrow();
   });
+
+  // ── Catapult HUD tests ──────────────────────────────────────────────────────
+  it("does not show catapult warning by default (player far from catapults)", () => {
+    const { queryByText } = render(<Game3D />);
+    act(() => { jest.advanceTimersByTime(0); });
+    // catapultWarning is false by default — warning banner must not be visible
+    expect(queryByText(/Katapult v blízkosti/)).toBeNull();
+  });
+
+  it("does not show catapult HP bar by default", () => {
+    const { queryByText } = render(<Game3D />);
+    act(() => { jest.advanceTimersByTime(0); });
+    // nearCatapultHp is null by default — HP display must not be visible
+    expect(queryByText(/^Katapult$/)).toBeNull();
+  });
+
+  it("does not show catapults defeated counter when count is 0", () => {
+    const { queryByText } = render(<Game3D />);
+    act(() => { jest.advanceTimersByTime(0); });
+    expect(queryByText(/Katapulty/)).toBeNull();
+  });
+
+  // ── Catapult intro objective tests ─────────────────────────────────────────
+
+  it("shows catapult destroy objective in intro overlay", () => {
+    const { getByText } = render(<Game3D />);
+    act(() => { jest.advanceTimersByTime(0); });
+    // Intro must list catapults as a combat objective
+    expect(getByText(/katapultů/i)).toBeInTheDocument();
+  });
+
+  it("shows cannonball warning text ('střílí kule') in catapult objective", () => {
+    const { getByText } = render(<Game3D />);
+    act(() => { jest.advanceTimersByTime(0); });
+    expect(getByText(/střílí kule/i)).toBeInTheDocument();
+  });
+
+  it("shows 💣 emoji for catapult objective in intro", () => {
+    const { getByText } = render(<Game3D />);
+    act(() => { jest.advanceTimersByTime(0); });
+    // The catapult objective starts with the 💣 emoji
+    expect(getByText(/💣/)).toBeInTheDocument();
+  });
 });

--- a/liquid-glass-clock/__tests__/meshBuilders.test.ts
+++ b/liquid-glass-clock/__tests__/meshBuilders.test.ts
@@ -37,6 +37,7 @@ import {
   buildSwordMesh,
   buildSniperMesh,
   buildBoatMesh,
+  buildCatapultMesh,
 } from "@/lib/meshBuilders";
 import * as THREE from "three";
 
@@ -628,5 +629,60 @@ describe("buildBoatMesh", () => {
     expect(boat.position.x).toBe(0);
     expect(boat.position.y).toBe(0);
     expect(boat.position.z).toBe(0);
+  });
+});
+
+describe("buildCatapultMesh", () => {
+  it("returns an object with a group and armGroup", () => {
+    const { group, armGroup } = buildCatapultMesh();
+    expect(group).toBeInstanceOf(THREE.Group);
+    expect(armGroup).toBeInstanceOf(THREE.Group);
+  });
+
+  it("armGroup is a child of the main group", () => {
+    const { group, armGroup } = buildCatapultMesh();
+    expect(group.children).toContain(armGroup);
+  });
+
+  it("arm starts in loaded (back) position (rotation.x ~= -1.1)", () => {
+    const { armGroup } = buildCatapultMesh();
+    expect(armGroup.rotation.x).toBeCloseTo(-1.1, 1);
+  });
+
+  it("group is positioned at origin by default", () => {
+    const { group } = buildCatapultMesh();
+    expect(group.position.x).toBe(0);
+    expect(group.position.y).toBe(0);
+    expect(group.position.z).toBe(0);
+  });
+
+  it("main group contains at least 10 child objects (frame, wheels, arm, etc.)", () => {
+    const { group } = buildCatapultMesh();
+    // Traverse all descendants and count meshes
+    let meshCount = 0;
+    group.traverse((child) => {
+      if ((child as THREE.Mesh).isMesh) meshCount++;
+    });
+    expect(meshCount).toBeGreaterThanOrEqual(10);
+  });
+
+  it("arm group contains the arm beam and counterweight", () => {
+    const { armGroup } = buildCatapultMesh();
+    let meshCount = 0;
+    armGroup.traverse((child) => {
+      if ((child as THREE.Mesh).isMesh) meshCount++;
+    });
+    // long arm, short arm, counterweight block, two sling ropes, cannonball = 6+
+    expect(meshCount).toBeGreaterThanOrEqual(4);
+  });
+
+  it("uses MeshLambertMaterial on all mesh descendants", () => {
+    const { group } = buildCatapultMesh();
+    group.traverse((child) => {
+      const mesh = child as THREE.Mesh;
+      if (mesh.isMesh) {
+        expect(mesh.material).toBeInstanceOf(THREE.MeshLambertMaterial);
+      }
+    });
   });
 });

--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -56,10 +56,11 @@ import {
   buildSwordMesh,
   buildSniperMesh,
   buildBoatMesh,
+  buildCatapultMesh,
   type SheepMeshParts,
   type RuinsResult,
 } from "@/lib/meshBuilders";
-import type { SheepData, FoxData, CoinData, BulletData, GameState, WeaponType } from "@/lib/gameTypes";
+import type { SheepData, FoxData, CoinData, BulletData, CatapultData, CannonballData, ImpactEffect, GameState, WeaponType } from "@/lib/gameTypes";
 import { WEAPON_CONFIGS } from "@/lib/gameTypes";
 import { soundManager } from "@/lib/soundManager";
 import { useMultiplayer, type PlayerUpdate } from "@/hooks/useMultiplayer";
@@ -101,6 +102,22 @@ const FOX_MAX_HP = 60;
 const FOX_ATTACK_DAMAGE = 9; // per second of direct contact
 const FOX_ATTACK_RANGE = 2.5;
 const FOX_PLAYER_CHASE_RADIUS = 22; // foxes chase player if this close
+
+// ─── Catapult Constants ────────────────────────────────────────────────────────
+const CATAPULT_COUNT = 6;
+const CATAPULT_MAX_HP = 180;
+const CATAPULT_FIRE_RANGE = 90;    // fires cannonballs when player is within this distance
+const CATAPULT_FIRE_COOLDOWN = 4;  // seconds between shots
+const CATAPULT_HIT_RADIUS = 2.8;   // for player bullet collisions vs catapult body
+
+// ─── Cannonball Constants ─────────────────────────────────────────────────────
+const CANNONBALL_SPEED = 22;       // units/s launch speed
+const CANNONBALL_DAMAGE = 28;      // damage dealt to player on hit
+const CANNONBALL_LIFETIME = 8;     // seconds before auto-despawn
+const CANNONBALL_HIT_RADIUS = 1.6; // sphere radius for player collision
+const CANNONBALL_GRAVITY = -14;    // vertical acceleration (lofted arc)
+const CANNONBALL_SHADOW_MAX_SCALE = 3.2; // ground-shadow disc max diameter
+const IMPACT_EFFECT_DURATION = 0.45;     // seconds the impact explosion ring lasts
 
 // ─── Bullet / Weapon Constants ────────────────────────────────────────────────
 // Per-weapon values come from WEAPON_CONFIGS; these are shared constants:
@@ -445,6 +462,7 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
   const playerHpRef = useRef(PLAYER_MAX_HP);
   const playerAttackCooldownRef = useRef(0);
   const foxesDefeatedRef = useRef(0);
+  const catapultsDefeatedRef = useRef(0);
   const isMouseHeldRef = useRef(false); // true while left mouse button is held down
 
   // ─── Weapon / Bullet Refs ───────────────────────────────────────────────────
@@ -452,6 +470,11 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
   const weaponMeshRef = useRef<THREE.Group | null>(null);
   const weaponRecoilRef = useRef(0); // 1 = just fired, decays to 0
   const muzzleFlashRef = useRef<THREE.PointLight | null>(null);
+
+  // ─── Catapult / Cannonball Refs ──────────────────────────────────────────────
+  const catapultListRef = useRef<CatapultData[]>([]);
+  const cannonballsRef = useRef<CannonballData[]>([]);
+  const impactEffectsRef = useRef<ImpactEffect[]>([]);
 
   // ─── Sound Refs ─────────────────────────────────────────────────────────────
   const footstepTimerRef = useRef(0);
@@ -525,8 +548,11 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     direction: "N",
     playerHp: PLAYER_MAX_HP,
     foxesDefeated: 0,
+    catapultsDefeated: 0,
     attackReady: true,
   });
+  const [nearCatapultHp, setNearCatapultHp] = useState<{ hp: number; maxHp: number } | null>(null);
+  const [catapultWarning, setCatapultWarning] = useState(false);
   const [showIntro, setShowIntro] = useState(true);
   const [showWeaponSelect, setShowWeaponSelect] = useState(false);
   const [gameStarted, setGameStarted] = useState(false);
@@ -718,6 +744,62 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     });
   }
 
+  // ─── Flash catapult mesh red on hit ──────────────────────────────────────────
+  function flashCatapultMesh(mesh: THREE.Group) {
+    mesh.traverse((child) => {
+      const m = child as THREE.Mesh;
+      if (m.isMesh && m.material) {
+        const mat = m.material as THREE.MeshLambertMaterial;
+        if (mat.emissive) {
+          mat.emissive.set(0xff2200);
+          setTimeout(() => mat.emissive.set(0x000000), 260);
+        }
+      }
+    });
+  }
+
+  // ─── Cannonball impact explosion ────────────────────────────────────────────
+  // Spawns an expanding ring + debris cloud at `pos` and queues it for update.
+  function spawnImpactEffect(scene: THREE.Scene, pos: THREE.Vector3) {
+    // Expanding shockwave ring
+    const ringGeo = new THREE.RingGeometry(0.1, 0.4, 16);
+    const ringMat = new THREE.MeshBasicMaterial({
+      color: 0xff6600,
+      transparent: true,
+      opacity: 0.85,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    });
+    const ring = new THREE.Mesh(ringGeo, ringMat);
+    ring.rotation.x = -Math.PI / 2;
+    ring.position.copy(pos);
+    ring.position.y += 0.1;
+    scene.add(ring);
+
+    // Small debris particles (8 tiny spheres that shoot outward)
+    const particles: THREE.Mesh[] = [];
+    for (let i = 0; i < 8; i++) {
+      const debrisMat = new THREE.MeshBasicMaterial({ color: 0x884400, transparent: true });
+      const pGeo = new THREE.SphereGeometry(0.1 + Math.random() * 0.12, 4, 3);
+      const p = new THREE.Mesh(pGeo, debrisMat);
+      const angle = (i / 8) * Math.PI * 2 + Math.random() * 0.5;
+      const radius = 0.3 + Math.random() * 0.4;
+      p.position.copy(pos);
+      p.position.x += Math.cos(angle) * radius;
+      p.position.z += Math.sin(angle) * radius;
+      p.position.y += 0.15 + Math.random() * 0.5;
+      scene.add(p);
+      particles.push(p);
+    }
+
+    impactEffectsRef.current.push({
+      ring,
+      particles,
+      age: 0,
+      maxAge: IMPACT_EFFECT_DURATION,
+    });
+  }
+
   // ─── Sheep highlight helpers (possession target) ─────────────────────────────
   function setSheepEmissive(sheep: SheepData, color: number) {
     sheep.mesh.traverse((child) => {
@@ -801,6 +883,35 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         fox.isAlive = false;
         foxesDefeatedRef.current++;
         soundManager.playFoxDeath();
+      }
+    }
+
+    // ── Melee hit on catapults ───────────────────────────────────────────────
+    if (weaponCfg.type === "sword") {
+      let closestCatapult: CatapultData | null = null;
+      let closestCatapultDist = weaponCfg.range * 2; // sword can reach catapult from a bit further
+
+      catapultListRef.current.forEach((cat) => {
+        if (!cat.isAlive) return;
+        const d = cat.mesh.position.distanceTo(playerPos);
+        if (d < closestCatapultDist) {
+          closestCatapultDist = d;
+          closestCatapult = cat;
+        }
+      });
+
+      if (closestCatapult) {
+        const cat = closestCatapult as CatapultData;
+        cat.hp = Math.max(0, cat.hp - weaponCfg.damage);
+        cat.hitFlashTimer = 0.3;
+        flashCatapultMesh(cat.mesh);
+        soundManager.playFoxHit();
+        setAttackEffect(`-${weaponCfg.damage}`);
+        setTimeout(() => setAttackEffect(null), 700);
+        if (cat.hp <= 0) {
+          cat.isAlive = false;
+          catapultsDefeatedRef.current++;
+        }
       }
     }
   }, []);
@@ -2135,6 +2246,36 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
       };
     });
 
+    // ── Catapults ─────────────────────────────────────────────────────────────
+    // Placed at fixed strategic positions around the map (not random so they
+    // don't spawn in water). 4 distant + 2 closer ones for early encounters.
+    const catapultPositions = [
+      { x:  80, z:  40 },
+      { x: -75, z:  55 },
+      { x:  60, z: -80 },
+      { x: -55, z: -65 },
+      { x:  38, z:  32 },   // closer to spawn — encountered early
+      { x: -34, z: -38 },   // closer to spawn — encountered early
+    ];
+    catapultListRef.current = catapultPositions.slice(0, CATAPULT_COUNT).map((p) => {
+      const { group, armGroup } = buildCatapultMesh();
+      const ty = getTerrainHeightSampled(p.x, p.z);
+      group.position.set(p.x, ty, p.z);
+      // Face toward the map centre (player spawn area)
+      group.rotation.y = Math.atan2(-p.x, -p.z);
+      scene.add(group);
+      return {
+        mesh: group,
+        armGroup,
+        hp: CATAPULT_MAX_HP,
+        maxHp: CATAPULT_MAX_HP,
+        isAlive: true,
+        fireCooldown: 1 + Math.random() * 3, // stagger initial shots
+        hitFlashTimer: 0,
+        firingAnimation: 0,
+      };
+    });
+
     // ── Coins / Gems ─────────────────────────────────────────────────────────
     const coinPoints = generateSpawnPoints(COIN_COUNT, 20, 350, 555);
     coinsRef.current = coinPoints.map((p) => {
@@ -3370,6 +3511,7 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         bullet.mesh.position.addScaledVector(bullet.velocity, dt);
 
         // Check fox collisions
+        let bulletHit = false;
         for (const fox of foxListRef.current) {
           if (!fox.isAlive) continue;
           const dist = bullet.mesh.position.distanceTo(fox.mesh.position);
@@ -3387,7 +3529,31 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
               soundManager.playFoxDeath();
             }
             toRemove.push(bullet);
+            bulletHit = true;
             break;
+          }
+        }
+
+        // Check catapult collisions (bullets can damage catapults)
+        if (!bulletHit) {
+          for (const cat of catapultListRef.current) {
+            if (!cat.isAlive) continue;
+            const dist = bullet.mesh.position.distanceTo(cat.mesh.position);
+            if (dist < CATAPULT_HIT_RADIUS) {
+              const dmg = WEAPON_CONFIGS[selectedWeaponRef.current].damage;
+              cat.hp = Math.max(0, cat.hp - dmg);
+              cat.hitFlashTimer = 0.3;
+              flashCatapultMesh(cat.mesh);
+              soundManager.playFoxHit();
+              setAttackEffect(`-${dmg}`);
+              setTimeout(() => setAttackEffect(null), 700);
+              if (cat.hp <= 0) {
+                cat.isAlive = false;
+                catapultsDefeatedRef.current++;
+              }
+              toRemove.push(bullet);
+              break;
+            }
           }
         }
       });
@@ -3544,6 +3710,215 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         setNearFoxHp({ hp: f.hp, maxHp: f.maxHp, name: "Liška" });
       } else {
         setNearFoxHp(null);
+      }
+
+      // ── Catapult AI ─────────────────────────────────────────────────────────
+      let catapultNear = false;
+      let closestAliveCatapult: CatapultData | null = null;
+      let closestCatapultDist = Infinity;
+
+      catapultListRef.current.forEach((cat) => {
+        const cm = cat.mesh;
+
+        // Death animation: scale down then hide
+        if (!cat.isAlive) {
+          if (cm.visible) {
+            cm.scale.setScalar(Math.max(0, cm.scale.x - dt * 3));
+            if (cm.scale.x <= 0.01) cm.visible = false;
+          }
+          return;
+        }
+
+        // Hit flash timer
+        if (cat.hitFlashTimer > 0) {
+          cat.hitFlashTimer = Math.max(0, cat.hitFlashTimer - dt);
+        }
+
+        const distToPlayer = cm.position.distanceTo(playerPos);
+
+        // Track nearest alive catapult for HP display
+        if (distToPlayer < closestCatapultDist) {
+          closestCatapultDist = distToPlayer;
+          closestAliveCatapult = cat;
+        }
+
+        if (distToPlayer < 30) catapultNear = true;
+
+        // Rotate catapult to face player
+        const dx = playerPos.x - cm.position.x;
+        const dz = playerPos.z - cm.position.z;
+        const targetYaw = Math.atan2(-dx, -dz);
+        cm.rotation.y += (targetYaw - cm.rotation.y) * Math.min(1, dt * 1.2);
+
+        // Firing animation: arm swings forward on fire
+        if (cat.firingAnimation > 0) {
+          cat.firingAnimation = Math.max(0, cat.firingAnimation - dt * 2.5);
+          // Arm rotation: rest = -1.1 rad (loaded), peak = +0.8 rad (released), then back
+          const t = cat.firingAnimation;
+          const armRot = t > 0.5
+            ? THREE.MathUtils.lerp(0.8, -1.1, (t - 0.5) * 2)   // swing forward
+            : THREE.MathUtils.lerp(-1.1, 0.8, 1 - t * 2);       // snap to release
+          cat.armGroup.rotation.x = armRot;
+        } else {
+          // Slowly return to loaded position
+          cat.armGroup.rotation.x += (-1.1 - cat.armGroup.rotation.x) * Math.min(1, dt * 1.5);
+        }
+
+        // Fire at player if in range and cooldown is ready
+        cat.fireCooldown -= dt;
+        if (cat.fireCooldown <= 0 && distToPlayer < CATAPULT_FIRE_RANGE) {
+          cat.fireCooldown = CATAPULT_FIRE_COOLDOWN + (Math.random() - 0.5) * 1.5;
+          cat.firingAnimation = 1.0;
+
+          // Spawn cannonball from the tip of the arm (roughly 3 units above catapult)
+          const launchPos = cm.position.clone();
+          launchPos.y += 3.5;
+
+          // Aim toward player with a slight upward arc
+          const toDx = playerPos.x - launchPos.x;
+          const toDz = playerPos.z - launchPos.z;
+          const horizontal = Math.sqrt(toDx * toDx + toDz * toDz);
+          const launchAngle = Math.atan2(CANNONBALL_SPEED * 0.65, horizontal); // arc
+          const cosA = Math.cos(launchAngle);
+          const sinA = Math.sin(launchAngle);
+          const hSpeed = CANNONBALL_SPEED * cosA;
+          const vSpeed = CANNONBALL_SPEED * sinA;
+
+          // Larger, glowing cannonball for visibility
+          const ballGeo = new THREE.SphereGeometry(0.38, 9, 6);
+          const ballMat = new THREE.MeshLambertMaterial({
+            color: 0x1a1a1a,
+            emissive: 0x552200,   // faint ember glow
+          });
+          const ballMesh = new THREE.Mesh(ballGeo, ballMat);
+          ballMesh.position.copy(launchPos);
+          ballMesh.castShadow = true;
+          scene.add(ballMesh);
+
+          // Ground-shadow disc: flat dark circle projected to terrain below ball
+          const shadowGeo = new THREE.CircleGeometry(1, 12);
+          const shadowMat = new THREE.MeshBasicMaterial({
+            color: 0x000000,
+            transparent: true,
+            opacity: 0.45,
+            depthWrite: false,
+            side: THREE.DoubleSide,
+          });
+          const shadowMesh = new THREE.Mesh(shadowGeo, shadowMat);
+          shadowMesh.rotation.x = -Math.PI / 2;
+          shadowMesh.renderOrder = -1;
+          scene.add(shadowMesh);
+
+          const dirH = horizontal > 0.001
+            ? new THREE.Vector3(toDx / horizontal, 0, toDz / horizontal)
+            : new THREE.Vector3(0, 0, 1);
+
+          cannonballsRef.current.push({
+            mesh: ballMesh,
+            shadowMesh,
+            velocity: new THREE.Vector3(
+              dirH.x * hSpeed,
+              vSpeed,
+              dirH.z * hSpeed
+            ),
+            lifetime: CANNONBALL_LIFETIME,
+          });
+        }
+      });
+
+      setCatapultWarning(catapultNear);
+
+      if (closestAliveCatapult && closestCatapultDist < 35) {
+        const c = closestAliveCatapult as CatapultData;
+        setNearCatapultHp({ hp: c.hp, maxHp: c.maxHp });
+      } else {
+        setNearCatapultHp(null);
+      }
+
+      // ── Cannonball update ────────────────────────────────────────────────────
+      const cannonballsToRemove: CannonballData[] = [];
+      cannonballsRef.current.forEach((ball) => {
+        ball.lifetime -= dt;
+        if (ball.lifetime <= 0) {
+          cannonballsToRemove.push(ball);
+          return;
+        }
+
+        // Apply gravity (arc trajectory)
+        ball.velocity.y += CANNONBALL_GRAVITY * dt;
+        ball.mesh.position.addScaledVector(ball.velocity, dt);
+
+        const bx = ball.mesh.position.x;
+        const bz = ball.mesh.position.z;
+        const groundY = getTerrainHeightSampled(bx, bz);
+
+        // Update ground-shadow: project disc to terrain, scale with altitude
+        const altitude = Math.max(0, ball.mesh.position.y - groundY);
+        const shadowScale = Math.min(CANNONBALL_SHADOW_MAX_SCALE, 0.5 + altitude * 0.18);
+        ball.shadowMesh.position.set(bx, groundY + 0.06, bz);
+        ball.shadowMesh.scale.setScalar(shadowScale);
+        // Fade shadow as ball gets very high (more transparent = farther away)
+        const shadowMat = ball.shadowMesh.material as THREE.MeshBasicMaterial;
+        shadowMat.opacity = Math.max(0.06, 0.45 - altitude * 0.006);
+
+        // Despawn below terrain — show impact explosion
+        if (ball.mesh.position.y < groundY) {
+          spawnImpactEffect(scene, new THREE.Vector3(bx, groundY, bz));
+          cannonballsToRemove.push(ball);
+          return;
+        }
+
+        // Check player collision
+        if (!gameOver) {
+          const distToPlayer = ball.mesh.position.distanceTo(playerPos);
+          if (distToPlayer < CANNONBALL_HIT_RADIUS) {
+            playerHpRef.current = Math.max(0, playerHpRef.current - CANNONBALL_DAMAGE);
+            setHitFlash(true);
+            setTimeout(() => setHitFlash(false), 350);
+            soundManager.playPlayerHit();
+            spawnImpactEffect(scene, ball.mesh.position.clone());
+            cannonballsToRemove.push(ball);
+          }
+        }
+      });
+
+      if (cannonballsToRemove.length > 0) {
+        cannonballsToRemove.forEach((b) => {
+          scene.remove(b.mesh);
+          scene.remove(b.shadowMesh);
+        });
+        cannonballsRef.current = cannonballsRef.current.filter(
+          (b) => !cannonballsToRemove.includes(b)
+        );
+      }
+
+      // ── Impact effects update ──────────────────────────────────────────────
+      const doneEffects: ImpactEffect[] = [];
+      impactEffectsRef.current.forEach((fx) => {
+        fx.age += dt;
+        const t = fx.age / fx.maxAge; // 0..1
+        if (t >= 1) {
+          doneEffects.push(fx);
+          return;
+        }
+        // Expand ring and fade it out
+        const ringScale = 1 + t * 8;
+        fx.ring.scale.setScalar(ringScale);
+        (fx.ring.material as THREE.MeshBasicMaterial).opacity = 0.85 * (1 - t);
+        // Lift and fade debris particles
+        fx.particles.forEach((p, i) => {
+          p.position.y += dt * (1.5 + i * 0.3);
+          (p.material as THREE.MeshBasicMaterial).opacity = 1 - t;
+        });
+      });
+      if (doneEffects.length > 0) {
+        doneEffects.forEach((fx) => {
+          scene.remove(fx.ring);
+          fx.particles.forEach((p) => scene.remove(p));
+        });
+        impactEffectsRef.current = impactEffectsRef.current.filter(
+          (fx) => !doneEffects.includes(fx)
+        );
       }
 
       // ── Possession proximity — find nearest sheep, manage highlight ──────────
@@ -3887,6 +4262,7 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         direction: getDirection(yawRef.current),
         playerHp: playerHpRef.current,
         foxesDefeated: foxesDefeatedRef.current,
+        catapultsDefeated: catapultsDefeatedRef.current,
         attackReady: playerAttackCooldownRef.current <= 0,
       }));
 
@@ -3948,6 +4324,12 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
       // Clean up any live bullets from the scene
       bulletsRef.current.forEach((b) => scene.remove(b.mesh));
       bulletsRef.current = [];
+      // Clean up cannonballs and their shadow discs
+      cannonballsRef.current.forEach((b) => { scene.remove(b.mesh); scene.remove(b.shadowMesh); });
+      cannonballsRef.current = [];
+      // Clean up impact effects
+      impactEffectsRef.current.forEach((fx) => { scene.remove(fx.ring); fx.particles.forEach((p) => scene.remove(p)); });
+      impactEffectsRef.current = [];
       // Clean up remote player meshes
       remotePlayersRef.current.forEach((data) => scene.remove(data.mesh));
       remotePlayersRef.current.clear();
@@ -4132,6 +4514,20 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
                   <span className="text-xs" style={{ color: "rgba(255,255,255,0.60)" }}>🦊 Poraženo</span>
                   <span className="text-xs font-bold text-orange-300 tabular-nums">
                     {gameState.foxesDefeated}
+                  </span>
+                </div>
+              </>
+            )}
+
+            {/* Catapults defeated (conditional) */}
+            {gameState.catapultsDefeated > 0 && (
+              <>
+                <div style={{ borderTop: "1px solid rgba(255,255,255,0.07)", margin: "16px 0 14px" }} />
+                <div className="flex justify-between items-center">
+                  <span className="text-xs" style={{ color: "rgba(255,255,255,0.60)" }}>⚔️ Katapulty</span>
+                  <span className="text-xs font-bold tabular-nums" style={{ color: "#fbbf24" }}>
+                    {gameState.catapultsDefeated}
+                    <span style={{ color: "rgba(255,255,255,0.30)" }}> / {CATAPULT_COUNT}</span>
                   </span>
                 </div>
               </>
@@ -4381,6 +4777,58 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         </div>
       )}
 
+      {/* ═══════════════ CENTER TOP — Catapult warning ═══════════════ */}
+      {catapultWarning && !foxWarning && gameState.isLocked && (
+        <div className="fixed top-5 left-1/2 -translate-x-1/2 pointer-events-none select-none" style={{ zIndex: 61 }}>
+          <div
+            className="rounded-xl text-white font-bold text-sm animate-pulse"
+            style={{
+              padding: "10px 22px",
+              background: "rgba(100,50,0,0.88)",
+              backdropFilter: "blur(10px)",
+              border: "1px solid rgba(255,180,30,0.35)",
+              boxShadow: "0 0 22px rgba(200,120,0,0.50)",
+            }}
+          >
+            ⚔️ Katapult v blízkosti!
+          </div>
+        </div>
+      )}
+
+      {/* ═══════════════ CENTER — Nearest catapult HP ═══════════════ */}
+      {nearCatapultHp && gameState.isLocked && (
+        <div className="fixed bottom-52 left-1/2 -translate-x-1/2 pointer-events-none select-none" style={{ zIndex: 60 }}>
+          <div
+            className="rounded-2xl text-white text-xs text-center"
+            style={{
+              padding: "12px 22px 14px",
+              background: "rgba(5,8,20,0.72)",
+              backdropFilter: "blur(14px)",
+              border: "1px solid rgba(255,180,40,0.20)",
+              minWidth: 200,
+              boxShadow: "0 4px 20px rgba(0,0,0,0.5)",
+            }}
+          >
+            <div className="font-bold text-sm" style={{ color: "#fbbf24", marginBottom: 8 }}>
+              Katapult
+            </div>
+            <div className="h-3 rounded-full overflow-hidden" style={{ background: "rgba(255,255,255,0.08)", marginBottom: 6 }}>
+              <div
+                className="h-full rounded-full transition-all duration-100"
+                style={{
+                  width: `${(nearCatapultHp.hp / nearCatapultHp.maxHp) * 100}%`,
+                  background: nearCatapultHp.hp > nearCatapultHp.maxHp * 0.5 ? "#f59e0b" : "#ef4444",
+                  boxShadow: "0 0 8px #f59e0b66",
+                }}
+              />
+            </div>
+            <div style={{ color: "rgba(255,255,255,0.40)" }} className="text-xs tabular-nums">
+              {nearCatapultHp.hp} / {nearCatapultHp.maxHp}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* ═══════════════ CENTER — Nearest fox HP ═══════════════ */}
       {nearFoxHp && gameState.isLocked && (
         <div className="fixed bottom-28 left-1/2 -translate-x-1/2 pointer-events-none select-none">
@@ -4595,10 +5043,16 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
           >
             <div className="text-5xl" style={{ marginBottom: 16 }}>💀</div>
             <h2 className="text-3xl font-bold" style={{ marginBottom: 12 }}>Byl jsi poražen!</h2>
-            <p className="text-gray-400 text-sm" style={{ marginBottom: 8 }}>Lišky tě dostaly…</p>
-            <p className="text-gray-500 text-xs" style={{ marginBottom: 28 }}>
+            <p className="text-gray-400 text-sm" style={{ marginBottom: 8 }}>Lišky nebo katapulty tě dostaly…</p>
+            <p className="text-gray-500 text-xs" style={{ marginBottom: 4 }}>
               Porazil jsi <span className="text-orange-400 font-bold">{gameState.foxesDefeated}</span> lišek
             </p>
+            {gameState.catapultsDefeated > 0 && (
+              <p className="text-gray-500 text-xs" style={{ marginBottom: 28 }}>
+                Zničil jsi <span className="font-bold" style={{ color: "#fbbf24" }}>{gameState.catapultsDefeated}</span> katapultů
+              </p>
+            )}
+            {gameState.catapultsDefeated === 0 && <div style={{ marginBottom: 28 }} />}
             <button
               className="bg-red-700 hover:bg-red-600 transition-colors text-white font-bold rounded-xl text-lg w-full"
               style={{ padding: "14px 32px" }}
@@ -4917,6 +5371,7 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
                 <div>🌟 Sesbírej <strong className="text-yellow-300">{COIN_COUNT} mincí</strong></div>
                 <div>🏚 Prozkoumej <strong className="text-white">ruiny</strong> a vesnici</div>
                 <div>🦊 <strong className="text-orange-400">Bojuj s liškami</strong> [F] nebo drž klik</div>
+                <div>💣 Znič <strong className="text-yellow-400">{CATAPULT_COUNT} katapultů</strong> — střílí kule!</div>
                 <div>⚓ Najdi <strong className="text-white">maják</strong> na pobřeží</div>
                 <div>🧱 <strong className="text-green-300">Stav budovy</strong> stiskni [B]</div>
                 <div>⛏ <strong className="text-cyan-300">Tvaruj terén</strong> v stavění [T]</div>

--- a/liquid-glass-clock/components/LobbyScreen.tsx
+++ b/liquid-glass-clock/components/LobbyScreen.tsx
@@ -317,6 +317,7 @@ export default function LobbyScreen({ onJoin }: Props) {
             <div>🌅 Dynamický den/noc</div>
             <div>🌟 Sesbírej mince</div>
             <div>🦊 Bojuj s liškami</div>
+            <div>💣 Znič katapulty</div>
           </div>
         </div>
       </div>

--- a/liquid-glass-clock/lib/gameTypes.ts
+++ b/liquid-glass-clock/lib/gameTypes.ts
@@ -105,6 +105,39 @@ export interface BulletData {
   lifetime: number; // seconds remaining before despawn
 }
 
+export interface CatapultData {
+  mesh: THREE.Group;
+  /** The rotating arm group — pivots around the X axis on fire. */
+  armGroup: THREE.Group;
+  hp: number;
+  maxHp: number;
+  isAlive: boolean;
+  /** Countdown in seconds until the catapult can fire again. */
+  fireCooldown: number;
+  /** Flash red on hit; counts down to 0. */
+  hitFlashTimer: number;
+  /** 0 = rest position, increases to 1 on fire then resets (arm swing animation). */
+  firingAnimation: number;
+}
+
+export interface CannonballData {
+  mesh: THREE.Mesh;
+  /** Flat shadow disc projected to terrain below the ball */
+  shadowMesh: THREE.Mesh;
+  velocity: THREE.Vector3;
+  lifetime: number; // seconds remaining before despawn
+}
+
+/** A brief impact explosion ring that expands and fades on cannonball landing. */
+export interface ImpactEffect {
+  /** Flat ring mesh that scales outward */
+  ring: THREE.Mesh;
+  /** Upward-smoke group containing several small particles */
+  particles: THREE.Mesh[];
+  age: number;     // seconds elapsed
+  maxAge: number;  // total life in seconds
+}
+
 export interface GameState {
   sheepCollected: number;
   coinsCollected: number;
@@ -116,5 +149,6 @@ export interface GameState {
   direction: string;
   playerHp: number;
   foxesDefeated: number;
+  catapultsDefeated: number;
   attackReady: boolean;
 }

--- a/liquid-glass-clock/lib/meshBuilders.ts
+++ b/liquid-glass-clock/lib/meshBuilders.ts
@@ -1150,3 +1150,137 @@ export function buildBoatMesh(): THREE.Group {
   group.receiveShadow = true;
   return group;
 }
+
+// ─── Catapult ─────────────────────────────────────────────────────────────────
+// Returns the full catapult group and the arm sub-group (for fire animation).
+// The arm pivots around the X axis at its origin (which sits at axle height).
+export function buildCatapultMesh(): { group: THREE.Group; armGroup: THREE.Group } {
+  const group = new THREE.Group();
+
+  const wood    = new THREE.MeshLambertMaterial({ color: 0x8b5e3c });
+  const darkWood = new THREE.MeshLambertMaterial({ color: 0x4a2f1a });
+  const metal   = new THREE.MeshLambertMaterial({ color: 0x4a4a4a });
+  const rope    = new THREE.MeshLambertMaterial({ color: 0xc8a060 });
+
+  // ── Base frame ──────────────────────────────────────────────────────────────
+  // Two long side beams running front-to-back (along Z axis)
+  const sideBeamGeo = new THREE.BoxGeometry(0.22, 0.22, 3.4);
+  ([-0.72, 0.72] as const).forEach((x) => {
+    const beam = new THREE.Mesh(sideBeamGeo, wood);
+    beam.position.set(x, 0.11, 0);
+    beam.castShadow = true;
+    group.add(beam);
+  });
+
+  // Front and rear crossbars
+  const crossGeo = new THREE.BoxGeometry(1.65, 0.20, 0.20);
+  [-1.1, 0, 1.1].forEach((z) => {
+    const cross = new THREE.Mesh(crossGeo, darkWood);
+    cross.position.set(0, 0.12, z);
+    cross.castShadow = true;
+    group.add(cross);
+  });
+
+  // ── Wheels (4 total, pairs at front & rear) ──────────────────────────────────
+  const wheelGeo  = new THREE.CylinderGeometry(0.40, 0.40, 0.12, 12);
+  const spokeGeo  = new THREE.BoxGeometry(0.06, 0.70, 0.08);
+  ([-1, 1] as const).forEach((side) => {
+    ([-1.0, 1.0] as const).forEach((z) => {
+      const wheel = new THREE.Mesh(wheelGeo, darkWood);
+      wheel.rotation.z = Math.PI / 2;
+      wheel.position.set(side * 0.92, 0.40, z);
+      wheel.castShadow = true;
+      group.add(wheel);
+
+      // 4 spokes per wheel
+      for (let sp = 0; sp < 4; sp++) {
+        const spoke = new THREE.Mesh(spokeGeo, wood);
+        spoke.rotation.z = (sp * Math.PI) / 4;
+        spoke.position.copy(wheel.position);
+        spoke.position.x += side * 0.07;
+        group.add(spoke);
+      }
+
+      // Metal hub cap
+      const hubGeo = new THREE.CylinderGeometry(0.10, 0.10, 0.16, 8);
+      const hub = new THREE.Mesh(hubGeo, metal);
+      hub.rotation.z = Math.PI / 2;
+      hub.position.set(side * 0.92, 0.40, z);
+      group.add(hub);
+    });
+  });
+
+  // ── Upright A-frame supports ─────────────────────────────────────────────────
+  const AXLE_Y = 1.65; // height of the throwing arm axle
+  const uprightGeo = new THREE.BoxGeometry(0.18, AXLE_Y, 0.18);
+  // Two uprights, left and right, slightly forward of centre
+  ([-0.62, 0.62] as const).forEach((x) => {
+    const upright = new THREE.Mesh(uprightGeo, wood);
+    upright.position.set(x, AXLE_Y / 2, -0.1);
+    upright.castShadow = true;
+    group.add(upright);
+
+    // Diagonal brace from base to mid-upright
+    const brace = new THREE.Mesh(new THREE.BoxGeometry(0.12, 1.30, 0.12), darkWood);
+    brace.position.set(x * 0.6, 0.8, 0.52);
+    brace.rotation.x = 0.55;
+    brace.castShadow = true;
+    group.add(brace);
+  });
+
+  // Axle cylinder
+  const axleGeo = new THREE.CylinderGeometry(0.075, 0.075, 1.55, 8);
+  const axle = new THREE.Mesh(axleGeo, metal);
+  axle.rotation.z = Math.PI / 2;
+  axle.position.set(0, AXLE_Y, -0.1);
+  group.add(axle);
+
+  // ── Throwing arm (pivots around axle) ────────────────────────────────────────
+  // Long end (sling) extends upward/forward; short end (counterweight) goes back.
+  const armGroup = new THREE.Group();
+  armGroup.position.set(0, AXLE_Y, -0.1); // pivot at axle
+  group.add(armGroup);
+
+  // Arm beam — long side (toward sling)
+  const longArmGeo = new THREE.BoxGeometry(0.14, 2.55, 0.14);
+  const longArm = new THREE.Mesh(longArmGeo, wood);
+  longArm.position.set(0, 1.275, 0); // extends upward from pivot
+  longArm.castShadow = true;
+  armGroup.add(longArm);
+
+  // Arm beam — short side (counterweight side)
+  const shortArmGeo = new THREE.BoxGeometry(0.14, 0.95, 0.14);
+  const shortArm = new THREE.Mesh(shortArmGeo, darkWood);
+  shortArm.position.set(0, -0.475, 0); // extends downward from pivot
+  shortArm.castShadow = true;
+  armGroup.add(shortArm);
+
+  // Counterweight block on short end
+  const cwGeo = new THREE.BoxGeometry(0.45, 0.45, 0.45);
+  const cw = new THREE.Mesh(cwGeo, metal);
+  cw.position.set(0, -1.1, 0);
+  cw.castShadow = true;
+  armGroup.add(cw);
+
+  // Sling rope (two thin cylinders forming a Y)
+  const slingGeo = new THREE.CylinderGeometry(0.025, 0.025, 0.70, 5);
+  ([-0.15, 0.15] as const).forEach((x) => {
+    const sling = new THREE.Mesh(slingGeo, rope);
+    sling.position.set(x, 2.8, 0);
+    sling.rotation.z = x > 0 ? -0.25 : 0.25;
+    armGroup.add(sling);
+  });
+
+  // Cannonball in sling (round stone)
+  const ballGeo = new THREE.SphereGeometry(0.22, 8, 6);
+  const ballMat = new THREE.MeshLambertMaterial({ color: 0x2a2a2a });
+  const ballMesh = new THREE.Mesh(ballGeo, ballMat);
+  ballMesh.position.set(0, 3.05, 0);
+  ballMesh.castShadow = true;
+  armGroup.add(ballMesh);
+
+  // Rest position: arm tilted back so sling is high behind
+  armGroup.rotation.x = -1.1;
+
+  return { group, armGroup };
+}


### PR DESCRIPTION
## Summary

Hotovo! Tady je přehled toho, co bylo implementováno:

**Katapulty v bojovém světě:**
- **6 katapultů** (bylo 4) — 2 blíže ke spawnu (~38 jednotek) pro časné setkání, 4 vzdálené (~60–80 jednotek)
- **Cooldown zkrácen** z 5 s na 4 s — katapulty střílí agresivněji
- **Větší dělové koule** (poloměr 0.38, bylo 0.22) s oranžovým žhavícím svitem — lépe viditelné za letu
- **Stín na zemi** pod každou koulí — plochý disk, který se zvětšuje s výškou, aby hráč věděl, kam koule dopadne a mohl se vyhnout
- **Explozní efekt** při dopadu — expandující šokový kruh + 8 trosek, které se rozletí a zmizí za ~0.45 s
- **Zmínka v intro** a lobby obrazovce: `💣 Znič 6 katapultů — střílí kule!`
- **3 nové testy** pro intro objectives katapultů

## Commits

- feat: add catapult enemies that fire cannonballs at the player