### PR TITLE
Po zmenseni mapy ted ve vzduchu levituji objekty obcas, zajisti, aby objekty mimo hranice sveta ted vubec nebyli

### DIFF
--- a/liquid-glass-clock/__tests__/terrainUtils.test.ts
+++ b/liquid-glass-clock/__tests__/terrainUtils.test.ts
@@ -219,6 +219,33 @@ describe("terrainUtils", () => {
       const pts = generateSpawnPoints(0, 20, 100, 1);
       expect(pts.length).toBe(0);
     });
+
+    it("never returns points outside world bounds even when maxDist exceeds world size", () => {
+      // maxDist of 380 used to push objects outside WORLD_SIZE=267 boundary (±133.5 units)
+      const pts = generateSpawnPoints(30, 10, 380, 42);
+      const halfWorld = WORLD_SIZE / 2;
+      pts.forEach((p) => {
+        expect(Math.abs(p.x)).toBeLessThanOrEqual(halfWorld);
+        expect(Math.abs(p.z)).toBeLessThanOrEqual(halfWorld);
+      });
+    });
+
+    it("never returns points outside world bounds for large radial maxDist values", () => {
+      // Simulates the original bush/coin/rock spawn calls that had maxDist > world half-size
+      const testCases = [
+        { count: 20, min: 20, max: 350, seed: 555 }, // coins
+        { count: 15, min: 8,  max: 340, seed: 7391 }, // bushes
+        { count: 10, min: 15, max: 380, seed: 456 }, // rocks
+      ];
+      const halfWorld = WORLD_SIZE / 2;
+      testCases.forEach(({ count, min, max, seed }) => {
+        const pts = generateSpawnPoints(count, min, max, seed);
+        pts.forEach((p) => {
+          expect(Math.abs(p.x)).toBeLessThanOrEqual(halfWorld);
+          expect(Math.abs(p.z)).toBeLessThanOrEqual(halfWorld);
+        });
+      });
+    });
   });
 
   describe("modifyTerrainHeight", () => {

--- a/liquid-glass-clock/lib/terrainUtils.ts
+++ b/liquid-glass-clock/lib/terrainUtils.ts
@@ -223,6 +223,10 @@ export function generateSpawnPoints(
     return (rng >>> 0) / 0xffffffff;
   };
 
+  // Keep objects at least this many units away from the world edge
+  const BOUNDARY_MARGIN = 8;
+  const halfWorld = WORLD_SIZE / 2 - BOUNDARY_MARGIN;
+
   let attempts = 0;
   while (points.length < count && attempts < count * 20) {
     attempts++;
@@ -230,6 +234,10 @@ export function generateSpawnPoints(
     const dist = minDist + rand() * (maxDist - minDist);
     const x = Math.cos(angle) * dist;
     const z = Math.sin(angle) * dist;
+
+    // Skip points outside the world square — they would float above the void
+    if (Math.abs(x) > halfWorld || Math.abs(z) > halfWorld) continue;
+
     const y = getTerrainHeight(x, z);
 
     // Don't spawn in water


### PR DESCRIPTION
## Summary

The fix was added to `generateSpawnPoints` in `terrainUtils.ts`: any candidate point whose `x` or `z` coordinate exceeds `WORLD_SIZE/2 - 8` is now skipped during generation, so objects can never be placed in the void beyond the terrain mesh. Two new tests verify this boundary enforcement holds even when callers pass `maxDist` values (380, 350, 340) far larger than the world half-size of 133.5 units.

## Commits

- fix: remove objects outside world boundaries to prevent levitation