### PR TITLE
Kdyz uzivatel umre, tak to po nem chce aby zadal znovu jmeno... udelej aby to jmeno byl alespon predvyplnene uz a stacil

### DIFF
--- a/liquid-glass-clock/__tests__/LobbyScreen.test.tsx
+++ b/liquid-glass-clock/__tests__/LobbyScreen.test.tsx
@@ -16,12 +16,14 @@ beforeEach(() => {
     ok: true,
     json: async () => ({ players: [] }),
   });
+  localStorage.clear();
 });
 
 afterEach(() => {
   jest.runOnlyPendingTimers();
   jest.useRealTimers();
   mockFetch.mockReset();
+  localStorage.clear();
 });
 
 describe("LobbyScreen component", () => {
@@ -223,5 +225,42 @@ describe("LobbyScreen component", () => {
     await expect(
       act(async () => { render(<LobbyScreen onJoin={() => {}} />); })
     ).resolves.not.toThrow();
+  });
+
+  it("pre-fills name input from localStorage if a name was previously saved", () => {
+    localStorage.setItem("playerName", "Franta");
+    render(<LobbyScreen onJoin={() => {}} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("Franta");
+  });
+
+  it("input starts empty when localStorage has no saved name", () => {
+    render(<LobbyScreen onJoin={() => {}} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  it("saves name to localStorage when joining", () => {
+    const onJoin = jest.fn();
+    render(<LobbyScreen onJoin={onJoin} />);
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Pepik" } });
+    fireEvent.click(screen.getByRole("button", { name: /vstoupit/i }));
+    expect(localStorage.getItem("playerName")).toBe("Pepik");
+  });
+
+  it("saves default name 'Hráč' to localStorage when joining with empty input", () => {
+    const onJoin = jest.fn();
+    render(<LobbyScreen onJoin={onJoin} />);
+    fireEvent.click(screen.getByRole("button", { name: /vstoupit/i }));
+    expect(localStorage.getItem("playerName")).toBe("Hráč");
+  });
+
+  it("uses pre-filled name from localStorage when joining without typing", () => {
+    localStorage.setItem("playerName", "Honza");
+    const onJoin = jest.fn();
+    render(<LobbyScreen onJoin={onJoin} />);
+    fireEvent.click(screen.getByRole("button", { name: /vstoupit/i }));
+    expect(onJoin).toHaveBeenCalledWith("Honza");
   });
 });

--- a/liquid-glass-clock/components/LobbyScreen.tsx
+++ b/liquid-glass-clock/components/LobbyScreen.tsx
@@ -12,19 +12,32 @@ interface OnlinePlayer {
   color: number;
 }
 
+const STORAGE_KEY = "playerName";
+
 export default function LobbyScreen({ onJoin }: Props) {
-  const [name, setName] = useState("");
+  const [name, setName] = useState(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem(STORAGE_KEY) ?? "";
+    }
+    return "";
+  });
   const [onlinePlayers, setOnlinePlayers] = useState<OnlinePlayer[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleJoin = useCallback(() => {
     const trimmed = name.trim();
-    onJoin(trimmed || "Hráč");
+    const finalName = trimmed || "Hráč";
+    localStorage.setItem(STORAGE_KEY, finalName);
+    onJoin(finalName);
   }, [name, onJoin]);
 
-  // Focus input on mount
+  // Focus input on mount and select all text so pre-filled name is easy to confirm or replace
   useEffect(() => {
-    inputRef.current?.focus();
+    const input = inputRef.current;
+    if (input) {
+      input.focus();
+      input.select();
+    }
   }, []);
 
   // Poll online player list every 4 seconds


### PR DESCRIPTION
## Summary

Hotovo. Po smrti hráče se nyní při reloadu stránky jméno automaticky předvyplní z `localStorage` – hráč stačí zmáčknout Enter nebo Mezerník a vrátí se do hry. Text je při načtení navíc automaticky označen (select), takže přepsání nového jména je stejně snadné. Jméno se do `localStorage` uloží vždy při kliknutí na "Vstoupit do světa".

## Commits

- feat: pre-fill player name from localStorage after death