### PR TITLE
zmen zbrane na mec, luk, kuse. V tomto poradi. Vytvor jim odpovidajici zvuky. Mec je zbran na blizko, takze se s nim bud

### DIFF
--- a/liquid-glass-clock/README.md
+++ b/liquid-glass-clock/README.md
@@ -20,9 +20,9 @@ Before starting, you choose one of three animated weapons:
 
 | Weapon | Type | Damage | Style |
 |---|---|---|---|
-| **Pistole** | Ranged | 25 | Balanced — bullet + close melee |
-| **Meč** | Melee only | 50 | High damage, short range, very fast |
-| **Sniperka** | Ranged | 90 | One-shot power, long range, slow reload |
+| **Meč** | Melee only | 55 | Fencing — high-speed sword swings, short range |
+| **Luk** | Ranged | 40 | Silent arrows — medium range, moderate reload |
+| **Kuše** | Ranged | 85 | Powerful bolt — long range, slow reload |
 
 Keys `[1]` `[2]` `[3]` select a weapon; `[Enter]` or the confirm button starts the game.
 
@@ -166,7 +166,7 @@ npm test
 Test suites (344+ tests total):
 - `__tests__/buildingSystem.test.ts` — block mesh builders, grid snapping, persistence
 - `__tests__/terrainUtils.test.ts` — terrain generation, spawn points, sculpt modification
-- `__tests__/meshBuilders.test.ts` — all 3D mesh builder functions (including sword & sniper)
+- `__tests__/meshBuilders.test.ts` — all 3D mesh builder functions (including sword, bow & crossbow)
 - `__tests__/soundManager.test.ts` — audio manager initialization and playback
 - `__tests__/Game3D.test.tsx` — Game3D component render, intro screen, and weapon select flow
 - `__tests__/WeaponSelect.test.tsx` — weapon selection UI, keyboard shortcuts, confirm callback

--- a/liquid-glass-clock/__tests__/WeaponSelect.test.tsx
+++ b/liquid-glass-clock/__tests__/WeaponSelect.test.tsx
@@ -18,16 +18,16 @@ describe("WeaponSelect component", () => {
 
   it("shows all three weapon cards", () => {
     render(<WeaponSelect onConfirm={jest.fn()} />);
-    expect(screen.getByTestId("weapon-card-pistol")).toBeInTheDocument();
     expect(screen.getByTestId("weapon-card-sword")).toBeInTheDocument();
-    expect(screen.getByTestId("weapon-card-sniper")).toBeInTheDocument();
+    expect(screen.getByTestId("weapon-card-bow")).toBeInTheDocument();
+    expect(screen.getByTestId("weapon-card-crossbow")).toBeInTheDocument();
   });
 
   it("shows weapon names in Czech", () => {
     render(<WeaponSelect onConfirm={jest.fn()} />);
-    expect(screen.getByText("Pistole")).toBeInTheDocument();
     expect(screen.getByText("Meč")).toBeInTheDocument();
-    expect(screen.getByText("Sniperka")).toBeInTheDocument();
+    expect(screen.getByText("Luk")).toBeInTheDocument();
+    expect(screen.getByText("Kuše")).toBeInTheDocument();
   });
 
   it("renders a confirm button", () => {
@@ -35,19 +35,19 @@ describe("WeaponSelect component", () => {
     expect(screen.getByTestId("weapon-confirm-btn")).toBeInTheDocument();
   });
 
-  it("defaults to pistol selected and confirm button says Pistole", () => {
+  it("defaults to sword selected and confirm button says Meč", () => {
     render(<WeaponSelect onConfirm={jest.fn()} />);
-    const btn = screen.getByTestId("weapon-confirm-btn");
-    expect(btn.textContent).toMatch(/Pistole/);
-  });
-
-  it("clicking a weapon card selects it", () => {
-    render(<WeaponSelect onConfirm={jest.fn()} />);
-    const swordCard = screen.getByTestId("weapon-card-sword");
-    fireEvent.click(swordCard);
-    // After clicking sword, confirm button should say Meč
     const btn = screen.getByTestId("weapon-confirm-btn");
     expect(btn.textContent).toMatch(/Meč/);
+  });
+
+  it("clicking bow weapon card selects it", () => {
+    render(<WeaponSelect onConfirm={jest.fn()} />);
+    const bowCard = screen.getByTestId("weapon-card-bow");
+    fireEvent.click(bowCard);
+    // After clicking bow, confirm button should say Luk
+    const btn = screen.getByTestId("weapon-confirm-btn");
+    expect(btn.textContent).toMatch(/Luk/);
   });
 
   it("clicking the confirm button calls onConfirm with selected weapon", () => {
@@ -55,46 +55,46 @@ describe("WeaponSelect component", () => {
     render(<WeaponSelect onConfirm={onConfirm} />);
     fireEvent.click(screen.getByTestId("weapon-confirm-btn"));
     expect(onConfirm).toHaveBeenCalledTimes(1);
-    expect(onConfirm).toHaveBeenCalledWith("pistol");
-  });
-
-  it("selecting sword and confirming calls onConfirm with 'sword'", () => {
-    const onConfirm = jest.fn();
-    render(<WeaponSelect onConfirm={onConfirm} />);
-    fireEvent.click(screen.getByTestId("weapon-card-sword"));
-    fireEvent.click(screen.getByTestId("weapon-confirm-btn"));
     expect(onConfirm).toHaveBeenCalledWith("sword");
   });
 
-  it("selecting sniper and confirming calls onConfirm with 'sniper'", () => {
+  it("selecting bow and confirming calls onConfirm with 'bow'", () => {
     const onConfirm = jest.fn();
     render(<WeaponSelect onConfirm={onConfirm} />);
-    fireEvent.click(screen.getByTestId("weapon-card-sniper"));
+    fireEvent.click(screen.getByTestId("weapon-card-bow"));
     fireEvent.click(screen.getByTestId("weapon-confirm-btn"));
-    expect(onConfirm).toHaveBeenCalledWith("sniper");
+    expect(onConfirm).toHaveBeenCalledWith("bow");
   });
 
-  it("keyboard shortcut '2' selects sword", () => {
+  it("selecting crossbow and confirming calls onConfirm with 'crossbow'", () => {
+    const onConfirm = jest.fn();
+    render(<WeaponSelect onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByTestId("weapon-card-crossbow"));
+    fireEvent.click(screen.getByTestId("weapon-confirm-btn"));
+    expect(onConfirm).toHaveBeenCalledWith("crossbow");
+  });
+
+  it("keyboard shortcut '2' selects bow", () => {
     render(<WeaponSelect onConfirm={jest.fn()} />);
     act(() => {
       fireEvent.keyDown(window, { key: "2" });
     });
     const btn = screen.getByTestId("weapon-confirm-btn");
-    expect(btn.textContent).toMatch(/Meč/);
+    expect(btn.textContent).toMatch(/Luk/);
   });
 
-  it("keyboard shortcut '3' selects sniper", () => {
+  it("keyboard shortcut '3' selects crossbow", () => {
     render(<WeaponSelect onConfirm={jest.fn()} />);
     act(() => {
       fireEvent.keyDown(window, { key: "3" });
     });
     const btn = screen.getByTestId("weapon-confirm-btn");
-    expect(btn.textContent).toMatch(/Sniperka/);
+    expect(btn.textContent).toMatch(/Kuše/);
   });
 
-  it("keyboard shortcut '1' selects pistol", () => {
+  it("keyboard shortcut '1' selects sword", () => {
     render(<WeaponSelect onConfirm={jest.fn()} />);
-    // First switch to sword, then back to pistol
+    // First switch to bow, then back to sword
     act(() => {
       fireEvent.keyDown(window, { key: "2" });
     });
@@ -102,7 +102,7 @@ describe("WeaponSelect component", () => {
       fireEvent.keyDown(window, { key: "1" });
     });
     const btn = screen.getByTestId("weapon-confirm-btn");
-    expect(btn.textContent).toMatch(/Pistole/);
+    expect(btn.textContent).toMatch(/Meč/);
   });
 
   it("Enter key calls onConfirm with currently selected weapon", () => {
@@ -114,7 +114,7 @@ describe("WeaponSelect component", () => {
     act(() => {
       fireEvent.keyDown(window, { key: "Enter" });
     });
-    expect(onConfirm).toHaveBeenCalledWith("sniper");
+    expect(onConfirm).toHaveBeenCalledWith("crossbow");
   });
 
   it("shows keyboard shortcut hints [1] [2] [3]", () => {
@@ -129,24 +129,24 @@ describe("WeaponSelect component", () => {
     expect(screen.getByText("Vyber zbraň")).toBeInTheDocument();
   });
 
-  it("pistol card is initially marked as pressed (selected)", () => {
-    render(<WeaponSelect onConfirm={jest.fn()} />);
-    const pistolCard = screen.getByTestId("weapon-card-pistol");
-    expect(pistolCard).toHaveAttribute("aria-pressed", "true");
-  });
-
-  it("sword card is not pressed by default", () => {
+  it("sword card is initially marked as pressed (selected)", () => {
     render(<WeaponSelect onConfirm={jest.fn()} />);
     const swordCard = screen.getByTestId("weapon-card-sword");
-    expect(swordCard).toHaveAttribute("aria-pressed", "false");
-  });
-
-  it("clicking sword card updates aria-pressed", () => {
-    render(<WeaponSelect onConfirm={jest.fn()} />);
-    const swordCard = screen.getByTestId("weapon-card-sword");
-    fireEvent.click(swordCard);
     expect(swordCard).toHaveAttribute("aria-pressed", "true");
-    // Pistol should be deselected
-    expect(screen.getByTestId("weapon-card-pistol")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("bow card is not pressed by default", () => {
+    render(<WeaponSelect onConfirm={jest.fn()} />);
+    const bowCard = screen.getByTestId("weapon-card-bow");
+    expect(bowCard).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("clicking bow card updates aria-pressed", () => {
+    render(<WeaponSelect onConfirm={jest.fn()} />);
+    const bowCard = screen.getByTestId("weapon-card-bow");
+    fireEvent.click(bowCard);
+    expect(bowCard).toHaveAttribute("aria-pressed", "true");
+    // Sword should be deselected
+    expect(screen.getByTestId("weapon-card-sword")).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/liquid-glass-clock/__tests__/meshBuilders.test.ts
+++ b/liquid-glass-clock/__tests__/meshBuilders.test.ts
@@ -33,9 +33,9 @@ import {
   buildRuins,
   buildLighthouse,
   buildBulletMesh,
-  buildWeaponMesh,
   buildSwordMesh,
-  buildSniperMesh,
+  buildBowMesh,
+  buildCrossbowMesh,
   buildBoatMesh,
   buildCatapultMesh,
 } from "@/lib/meshBuilders";
@@ -489,32 +489,35 @@ describe("buildBulletMesh", () => {
   });
 });
 
-describe("buildWeaponMesh", () => {
+describe("buildBowMesh", () => {
   it("returns a THREE.Group", () => {
-    const weapon = buildWeaponMesh();
-    expect(weapon).toBeInstanceOf(THREE.Group);
+    const bow = buildBowMesh();
+    expect(bow).toBeInstanceOf(THREE.Group);
   });
 
-  it("has multiple parts (slide, barrel, grip, guard, sight)", () => {
-    const weapon = buildWeaponMesh();
-    expect(weapon.children.length).toBeGreaterThanOrEqual(5);
+  it("has multiple parts (limbs, grip, string, arrow, fletching)", () => {
+    const bow = buildBowMesh();
+    expect(bow.children.length).toBeGreaterThanOrEqual(8);
   });
 
   it("all parts are THREE.Mesh instances", () => {
-    const weapon = buildWeaponMesh();
-    weapon.children.forEach((child) => {
+    const bow = buildBowMesh();
+    bow.children.forEach((child) => {
       expect(child).toBeInstanceOf(THREE.Mesh);
     });
   });
 
-  it("uses dark material colors (grey/black gun finish)", () => {
-    const weapon = buildWeaponMesh();
-    // Every material color should be dark (max channel < 0.35)
-    weapon.children.forEach((child) => {
+  it("uses wood-like brown colors for limbs", () => {
+    const bow = buildBowMesh();
+    // Check that at least one child has a brownish color (r > g > b)
+    let hasBrownish = false;
+    bow.children.forEach((child) => {
       const mat = (child as THREE.Mesh).material as THREE.MeshLambertMaterial;
-      const maxChannel = Math.max(mat.color.r, mat.color.g, mat.color.b);
-      expect(maxChannel).toBeLessThan(0.35);
+      if (mat.color.r > mat.color.g && mat.color.g > mat.color.b) {
+        hasBrownish = true;
+      }
     });
+    expect(hasBrownish).toBe(true);
   });
 });
 
@@ -548,34 +551,34 @@ describe("buildSwordMesh", () => {
   });
 });
 
-describe("buildSniperMesh", () => {
+describe("buildCrossbowMesh", () => {
   it("returns a THREE.Group", () => {
-    const sniper = buildSniperMesh();
-    expect(sniper).toBeInstanceOf(THREE.Group);
+    const crossbow = buildCrossbowMesh();
+    expect(crossbow).toBeInstanceOf(THREE.Group);
   });
 
-  it("has many parts (barrel, body, scope, stock, grip, bipod, etc.)", () => {
-    const sniper = buildSniperMesh();
-    expect(sniper.children.length).toBeGreaterThanOrEqual(10);
+  it("has many parts (stock, rail, limbs, stirrup, string, trigger, bolt, etc.)", () => {
+    const crossbow = buildCrossbowMesh();
+    expect(crossbow.children.length).toBeGreaterThanOrEqual(10);
   });
 
   it("all parts are THREE.Mesh instances", () => {
-    const sniper = buildSniperMesh();
-    sniper.children.forEach((child) => {
+    const crossbow = buildCrossbowMesh();
+    crossbow.children.forEach((child) => {
       expect(child).toBeInstanceOf(THREE.Mesh);
     });
   });
 
-  it("includes a glowing scope lens (emissive material)", () => {
-    const sniper = buildSniperMesh();
-    let hasEmissive = false;
-    sniper.children.forEach((child) => {
+  it("uses dark wood and metal colors", () => {
+    const crossbow = buildCrossbowMesh();
+    // At least one part should be dark (dark wood or metal)
+    let hasDark = false;
+    crossbow.children.forEach((child) => {
       const mat = (child as THREE.Mesh).material as THREE.MeshLambertMaterial;
-      if (mat.emissive && (mat.emissive.r > 0 || mat.emissive.g > 0 || mat.emissive.b > 0)) {
-        hasEmissive = true;
-      }
+      const brightness = mat.color.r + mat.color.g + mat.color.b;
+      if (brightness < 0.5) hasDark = true;
     });
-    expect(hasEmissive).toBe(true);
+    expect(hasDark).toBe(true);
   });
 });
 

--- a/liquid-glass-clock/__tests__/soundManager.test.ts
+++ b/liquid-glass-clock/__tests__/soundManager.test.ts
@@ -263,8 +263,20 @@ describe("SoundManager – sound effects don't throw", () => {
     expect(() => soundManager.playFoxGrowl()).not.toThrow();
   });
 
-  it("playAttack()", () => {
+  it("playAttack() – default (bow)", () => {
     expect(() => soundManager.playAttack()).not.toThrow();
+  });
+
+  it("playAttack('sword') – sword swish + metallic ring", () => {
+    expect(() => soundManager.playAttack("sword")).not.toThrow();
+  });
+
+  it("playAttack('bow') – bowstring twang + arrow whoosh", () => {
+    expect(() => soundManager.playAttack("bow")).not.toThrow();
+  });
+
+  it("playAttack('crossbow') – mechanical click + bolt release", () => {
+    expect(() => soundManager.playAttack("crossbow")).not.toThrow();
   });
 
   it("playFoxHit()", () => {
@@ -339,6 +351,14 @@ describe("SoundManager – graceful no-ops before init", () => {
 
   it("playAttack() before init does not throw", () => {
     expect(() => soundManager.playAttack()).not.toThrow();
+  });
+
+  it("playAttack('sword') before init does not throw", () => {
+    expect(() => soundManager.playAttack("sword")).not.toThrow();
+  });
+
+  it("playAttack('crossbow') before init does not throw", () => {
+    expect(() => soundManager.playAttack("crossbow")).not.toThrow();
   });
 
   it("playFoxHit() before init does not throw", () => {

--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -47,9 +47,9 @@ import {
   buildRuins,
   buildLighthouse,
   buildBulletMesh,
-  buildWeaponMesh,
   buildSwordMesh,
-  buildSniperMesh,
+  buildBowMesh,
+  buildCrossbowMesh,
   buildBoatMesh,
   buildCatapultMesh,
   type SheepMeshParts,
@@ -126,7 +126,7 @@ const IMPACT_EFFECT_DURATION = 0.45;     // seconds the impact explosion ring la
 // Per-weapon values come from WEAPON_CONFIGS; these are shared constants:
 const BULLET_LIFETIME = 4;      // seconds before auto-despawn
 const BULLET_HIT_RADIUS = 1.4;  // sphere radius for fox collision
-// Default weapon position in camera-local space (pistol)
+// Default weapon position in camera-local space (sword)
 const WEAPON_POS = new THREE.Vector3(0.24, -0.21, -0.48);
 
 // ─── Possession Constants ─────────────────────────────────────────────────────
@@ -398,8 +398,8 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
   const playerBodyLegPhaseRef = useRef(0);
 
   // ─── Selected weapon (persisted via ref for use inside animation loop) ───────
-  const [selectedWeapon, setSelectedWeapon] = useState<WeaponType>("pistol");
-  const selectedWeaponRef = useRef<WeaponType>("pistol");
+  const [selectedWeapon, setSelectedWeapon] = useState<WeaponType>("sword");
+  const selectedWeaponRef = useRef<WeaponType>("sword");
 
   // ─── Third-Person Camera Refs ────────────────────────────────────────────────
   const thirdPersonRef    = useRef(false);
@@ -597,19 +597,20 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     cam.remove(weaponMeshRef.current);
     // Build new mesh
     const newMesh =
-      type === "sword" ? buildSwordMesh()
-      : type === "sniper" ? buildSniperMesh()
-      : buildWeaponMesh();
+      type === "bow" ? buildBowMesh()
+      : type === "crossbow" ? buildCrossbowMesh()
+      : buildSwordMesh(); // sword
     if (type === "sword") {
       newMesh.position.set(0.20, -0.18, -0.38);
       newMesh.rotation.y = -0.25;
       newMesh.rotation.z = -0.05;
-    } else if (type === "sniper") {
-      newMesh.position.set(0.18, -0.22, -0.55);
-      newMesh.rotation.y = -0.08;
-    } else {
-      newMesh.position.copy(WEAPON_POS);
+    } else if (type === "bow") {
+      newMesh.position.set(0.16, -0.16, -0.40);
       newMesh.rotation.y = -0.12;
+    } else {
+      // crossbow
+      newMesh.position.set(0.18, -0.22, -0.52);
+      newMesh.rotation.y = -0.08;
     }
     cam.add(newMesh);
     weaponMeshRef.current = newMesh;
@@ -705,7 +706,7 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     const weaponCfg = WEAPON_CONFIGS[selectedWeaponRef.current];
 
     playerAttackCooldownRef.current = weaponCfg.cooldown;
-    soundManager.playAttack();
+    soundManager.playAttack(weaponCfg.type);
 
     // ── Weapon recoil kick ──────────────────────────────────────────────────
     weaponRecoilRef.current = 1;
@@ -897,20 +898,21 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     // ── First-person weapon (attached to camera) ─────────────────────────────
     const wType = selectedWeaponRef.current;
     const weaponGroup =
-      wType === "sword" ? buildSwordMesh()
-      : wType === "sniper" ? buildSniperMesh()
-      : buildWeaponMesh();
-    // Sword sits closer/lower and rotates differently for melee feel
+      wType === "bow" ? buildBowMesh()
+      : wType === "crossbow" ? buildCrossbowMesh()
+      : buildSwordMesh(); // sword
+    // Position each weapon in camera-local space
     if (wType === "sword") {
       weaponGroup.position.set(0.20, -0.18, -0.38);
       weaponGroup.rotation.y = -0.25;
       weaponGroup.rotation.z = -0.05;
-    } else if (wType === "sniper") {
-      weaponGroup.position.set(0.18, -0.22, -0.55);
-      weaponGroup.rotation.y = -0.08;
+    } else if (wType === "bow") {
+      weaponGroup.position.set(0.16, -0.16, -0.40);
+      weaponGroup.rotation.y = -0.12;
     } else {
-      weaponGroup.position.copy(WEAPON_POS);
-      weaponGroup.rotation.y = -0.12; // slight inward cant
+      // crossbow
+      weaponGroup.position.set(0.18, -0.22, -0.52);
+      weaponGroup.rotation.y = -0.08;
     }
     camera.add(weaponGroup);
     weaponMeshRef.current = weaponGroup;
@@ -2439,7 +2441,7 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
 
       // Digit keys 1–3 — select weapon in explore mode
       if (e.type === "keydown" && buildModeRef.current === "explore") {
-        const WEAPON_ORDER: WeaponType[] = ["pistol", "sword", "sniper"];
+        const WEAPON_ORDER: WeaponType[] = ["sword", "bow", "crossbow"];
         if (e.code === "Digit1" || e.code === "Digit2" || e.code === "Digit3") {
           const idx = parseInt(e.code.replace("Digit", "")) - 1;
           const newWeapon = WEAPON_ORDER[idx];
@@ -2547,7 +2549,7 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         setBuildingUiState((s) => ({ ...s, selectedMaterial: newMat }));
       } else if (buildModeRef.current === "explore") {
         // Mouse wheel — cycle through weapons
-        const WEAPON_ORDER: WeaponType[] = ["pistol", "sword", "sniper"];
+        const WEAPON_ORDER: WeaponType[] = ["sword", "bow", "crossbow"];
         const cur = WEAPON_ORDER.indexOf(selectedWeaponRef.current);
         const next = (cur + (e.deltaY > 0 ? 1 : -1) + WEAPON_ORDER.length) % WEAPON_ORDER.length;
         const newWeapon = WEAPON_ORDER[next];
@@ -3549,9 +3551,9 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         const swaySpeed = isMoving ? 7 : 3;
 
         const wType = selectedWeaponRef.current;
-        const baseX = wType === "sword" ? 0.20 : wType === "sniper" ? 0.18 : WEAPON_POS.x;
-        const baseY = wType === "sword" ? -0.18 : wType === "sniper" ? -0.22 : WEAPON_POS.y;
-        const baseZ = wType === "sword" ? -0.38 : wType === "sniper" ? -0.55 : WEAPON_POS.z;
+        const baseX = wType === "bow" ? 0.16 : wType === "crossbow" ? 0.18 : 0.20; // sword default
+        const baseY = wType === "bow" ? -0.16 : wType === "crossbow" ? -0.22 : -0.18; // sword default
+        const baseZ = wType === "bow" ? -0.40 : wType === "crossbow" ? -0.52 : -0.38; // sword default
         wep.position.set(
           baseX + Math.sin(elapsed * swaySpeed * 0.5) * swayAmt * 0.6,
           baseY + Math.abs(Math.sin(elapsed * swaySpeed)) * swayAmt - recoil * 0.04,
@@ -4771,10 +4773,10 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
           </div>
 
           {/* Weapon slots HUD — all 3 weapons, active one highlighted */}
-          {(["pistol", "sword", "sniper"] as WeaponType[]).map((w, idx) => {
+          {(["sword", "bow", "crossbow"] as WeaponType[]).map((w, idx) => {
             const cfg = WEAPON_CONFIGS[w];
             const isActive = selectedWeapon === w;
-            const emoji = w === "pistol" ? "🔫" : w === "sword" ? "⚔️" : "🎯";
+            const emoji = w === "sword" ? "⚔️" : w === "bow" ? "🏹" : "🎯";
             return (
               <div
                 key={w}

--- a/liquid-glass-clock/components/WeaponSelect.tsx
+++ b/liquid-glass-clock/components/WeaponSelect.tsx
@@ -6,74 +6,6 @@ import { WEAPON_CONFIGS } from "@/lib/gameTypes";
 
 // ─── Animated SVG weapons ─────────────────────────────────────────────────────
 
-function PistolSVG({ selected }: { selected: boolean }) {
-  return (
-    <svg
-      viewBox="0 0 120 80"
-      width="120"
-      height="80"
-      style={{
-        filter: selected ? "drop-shadow(0 0 8px #6ee7b7)" : "drop-shadow(0 2px 4px rgba(0,0,0,0.5))",
-        animation: "pistol-idle 3s ease-in-out infinite",
-      }}
-    >
-      <style>{`
-        @keyframes pistol-idle {
-          0%, 100% { transform: translateY(0px) rotate(0deg); }
-          30% { transform: translateY(-4px) rotate(-1.5deg); }
-          60% { transform: translateY(-2px) rotate(1deg); }
-        }
-        @keyframes pistol-slide-back {
-          0%, 80%, 100% { transform: translateX(0); }
-          40% { transform: translateX(5px); }
-        }
-        @keyframes barrel-flash {
-          0%, 85%, 100% { opacity: 0; }
-          87%, 92% { opacity: 1; }
-        }
-        @keyframes pistol-trigger {
-          0%, 100% { transform: rotate(0deg); transform-origin: 70px 55px; }
-          50% { transform: rotate(-8deg); transform-origin: 70px 55px; }
-        }
-      `}</style>
-      {/* Grip */}
-      <rect x="62" y="44" width="18" height="28" rx="3" fill="#2a2a2a" />
-      <rect x="63" y="46" width="16" height="6" rx="1" fill="#1a1a1a" opacity="0.5" />
-      {/* Frame */}
-      <rect x="30" y="42" width="44" height="14" rx="2" fill="#3a3a3a" />
-      {/* Slide (animated) */}
-      <g style={{ animation: "pistol-slide-back 4s ease-in-out infinite" }}>
-        <rect x="28" y="36" width="46" height="12" rx="2" fill="#282828" />
-        {/* Slide serrations */}
-        <line x1="60" y1="37" x2="60" y2="47" stroke="#1a1a1a" strokeWidth="1.5" />
-        <line x1="64" y1="37" x2="64" y2="47" stroke="#1a1a1a" strokeWidth="1.5" />
-        <line x1="68" y1="37" x2="68" y2="47" stroke="#1a1a1a" strokeWidth="1.5" />
-      </g>
-      {/* Barrel */}
-      <rect x="10" y="39" width="22" height="8" rx="3" fill="#1a1a1a" />
-      {/* Muzzle flash */}
-      <g style={{ animation: "barrel-flash 4s ease-in-out infinite" }}>
-        <ellipse cx="9" cy="43" rx="5" ry="3" fill="#ffdd44" opacity="0.9" />
-        <ellipse cx="7" cy="43" rx="3" ry="2" fill="#ffffff" opacity="0.8" />
-      </g>
-      {/* Trigger guard */}
-      <path d="M62 56 Q58 64 66 62" stroke="#555" strokeWidth="2.5" fill="none" strokeLinecap="round" />
-      {/* Trigger */}
-      <rect
-        x="68" y="52" width="3" height="8" rx="1" fill="#666"
-        style={{ animation: "pistol-trigger 2.5s ease-in-out infinite" }}
-      />
-      {/* Front sight */}
-      <rect x="20" y="36" width="4" height="4" rx="1" fill="#444" />
-      {/* Rear sight notch */}
-      <rect x="68" y="35" width="8" height="3" rx="1" fill="#333" />
-      <rect x="70.5" y="35.5" width="3" height="2" rx="0.5" fill="#1a1a1a" />
-      {/* Highlight */}
-      <rect x="28" y="36.5" width="46" height="2" rx="1" fill="white" opacity="0.08" />
-    </svg>
-  );
-}
-
 function SwordSVG({ selected }: { selected: boolean }) {
   return (
     <svg
@@ -100,18 +32,25 @@ function SwordSVG({ selected }: { selected: boolean }) {
           0%, 100% { opacity: 0.3; }
           50% { opacity: 0.7; }
         }
+        @keyframes sword-swing {
+          0%, 70%, 100% { transform: rotate(0deg); transform-origin: 100px 40px; }
+          80% { transform: rotate(-12deg); transform-origin: 100px 40px; }
+          88% { transform: rotate(8deg); transform-origin: 100px 40px; }
+        }
       `}</style>
-      {/* Blade */}
-      <polygon points="10,40 22,36 90,40 22,44" fill="#c8dff0" />
-      <polygon points="10,40 22,36 90,40" fill="#e0f0ff" opacity="0.7" />
-      {/* Blade edge */}
-      <line x1="10" y1="40" x2="90" y2="40" stroke="#ffffff" strokeWidth="0.8" opacity="0.6" />
-      {/* Blade center fuller */}
-      <line x1="22" y1="39.5" x2="88" y2="39.5" stroke="#88aacc" strokeWidth="0.6" opacity="0.5" />
-      {/* Blade shimmer highlight */}
-      <rect x="22" y="36.5" width="60" height="3" rx="1" fill="white" style={{ animation: "blade-shimmer 2.5s ease-in-out infinite" }} />
-      {/* Blade glow */}
-      <ellipse cx="50" cy="40" rx="38" ry="3" fill="#88ccff" style={{ animation: "sword-glow 2.5s ease-in-out infinite" }} />
+      <g style={{ animation: "sword-swing 3s ease-in-out infinite" }}>
+        {/* Blade */}
+        <polygon points="10,40 22,36 90,40 22,44" fill="#c8dff0" />
+        <polygon points="10,40 22,36 90,40" fill="#e0f0ff" opacity="0.7" />
+        {/* Blade edge */}
+        <line x1="10" y1="40" x2="90" y2="40" stroke="#ffffff" strokeWidth="0.8" opacity="0.6" />
+        {/* Blade center fuller */}
+        <line x1="22" y1="39.5" x2="88" y2="39.5" stroke="#88aacc" strokeWidth="0.6" opacity="0.5" />
+        {/* Blade shimmer highlight */}
+        <rect x="22" y="36.5" width="60" height="3" rx="1" fill="white" style={{ animation: "blade-shimmer 2.5s ease-in-out infinite" }} />
+        {/* Blade glow */}
+        <ellipse cx="50" cy="40" rx="38" ry="3" fill="#88ccff" style={{ animation: "sword-glow 2.5s ease-in-out infinite" }} />
+      </g>
       {/* Cross-guard */}
       <rect x="84" y="29" width="6" height="22" rx="2" fill="#c8960c" />
       <ellipse cx="87" cy="29" rx="3" ry="4" fill="#e8b020" />
@@ -132,7 +71,73 @@ function SwordSVG({ selected }: { selected: boolean }) {
   );
 }
 
-function SniperSVG({ selected }: { selected: boolean }) {
+function BowSVG({ selected }: { selected: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 120 80"
+      width="120"
+      height="80"
+      style={{
+        filter: selected ? "drop-shadow(0 0 10px #86efac)" : "drop-shadow(0 2px 4px rgba(0,0,0,0.5))",
+        animation: "bow-idle 4s ease-in-out infinite",
+      }}
+    >
+      <style>{`
+        @keyframes bow-idle {
+          0%, 100% { transform: translateY(0px) rotate(0deg); }
+          40% { transform: translateY(-4px) rotate(1deg); }
+          70% { transform: translateY(-2px) rotate(-0.8deg); }
+        }
+        @keyframes bow-draw {
+          0%, 75%, 100% { d: path("M30,12 Q18,40 30,68"); }
+          80% { d: path("M34,12 Q16,40 34,68"); }
+          88% { d: path("M30,12 Q18,40 30,68"); }
+        }
+        @keyframes string-vibrate {
+          0%, 70%, 100% { transform: scaleX(1); }
+          78% { transform: scaleX(1.04); }
+          84% { transform: scaleX(0.97); }
+          90% { transform: scaleX(1.02); }
+        }
+        @keyframes arrow-fly {
+          0%, 72%, 100% { opacity: 1; transform: translateX(0); }
+          73% { opacity: 1; transform: translateX(0); }
+          80% { opacity: 0; transform: translateX(50px); }
+          82%, 99% { opacity: 0; }
+        }
+      `}</style>
+
+      {/* Bow limb (curved path) */}
+      <path d="M30,10 Q15,40 30,70" stroke="#7a4a1a" strokeWidth="5" fill="none" strokeLinecap="round" />
+      {/* Bow limb highlight */}
+      <path d="M29,10 Q14,40 29,70" stroke="#a06030" strokeWidth="2" fill="none" strokeLinecap="round" opacity="0.5" />
+
+      {/* Bowstring */}
+      <g style={{ animation: "string-vibrate 3s ease-in-out infinite" }}>
+        <line x1="30" y1="10" x2="30" y2="70" stroke="#ddd0aa" strokeWidth="1.5" />
+      </g>
+
+      {/* Arrow */}
+      <g style={{ animation: "arrow-fly 3s ease-in-out infinite" }}>
+        {/* Arrow shaft */}
+        <line x1="30" y1="40" x2="90" y2="40" stroke="#8b5e3c" strokeWidth="3" strokeLinecap="round" />
+        {/* Arrowhead */}
+        <polygon points="90,40 80,36 82,40 80,44" fill="#aaaaaa" />
+        {/* Fletching */}
+        <polygon points="33,40 30,33 36,40" fill="#cc3333" opacity="0.85" />
+        <polygon points="33,40 30,47 36,40" fill="#cc3333" opacity="0.85" />
+      </g>
+
+      {/* Grip wrap */}
+      <rect x="25" y="34" width="9" height="12" rx="2" fill="#4a2a08" />
+      <line x1="26" y1="36" x2="33" y2="36" stroke="#3a1a04" strokeWidth="1.2" />
+      <line x1="26" y1="39" x2="33" y2="39" stroke="#3a1a04" strokeWidth="1.2" />
+      <line x1="26" y1="42" x2="33" y2="42" stroke="#3a1a04" strokeWidth="1.2" />
+    </svg>
+  );
+}
+
+function CrossbowSVG({ selected }: { selected: boolean }) {
   return (
     <svg
       viewBox="0 0 140 80"
@@ -140,89 +145,83 @@ function SniperSVG({ selected }: { selected: boolean }) {
       height="80"
       style={{
         filter: selected ? "drop-shadow(0 0 10px #f87171)" : "drop-shadow(0 2px 4px rgba(0,0,0,0.5))",
-        animation: "sniper-idle 5s ease-in-out infinite",
+        animation: "crossbow-idle 5s ease-in-out infinite",
       }}
     >
       <style>{`
-        @keyframes sniper-idle {
+        @keyframes crossbow-idle {
           0%, 100% { transform: translateY(0px) rotate(0deg); }
           40% { transform: translateY(-3px) rotate(-0.8deg); }
           70% { transform: translateY(-2px) rotate(0.5deg); }
         }
-        @keyframes scope-pulse {
-          0%, 100% { opacity: 0.6; r: 5; }
-          50% { opacity: 1; r: 7; }
+        @keyframes crossbow-recoil {
+          0%, 75%, 100% { transform: translateX(0); }
+          78% { transform: translateX(3px); }
+          83% { transform: translateX(-1px); }
+          88% { transform: translateX(1px); }
         }
-        @keyframes scope-lens-glow {
-          0%, 100% { opacity: 0.5; }
-          50% { opacity: 1; }
+        @keyframes crossbow-string {
+          0%, 74%, 100% { transform: scaleX(1); }
+          76% { transform: scaleX(1.05); }
+          82% { transform: scaleX(0.97); }
         }
-        @keyframes scope-crosshair {
-          0%, 100% { opacity: 0.4; }
-          30% { opacity: 0.9; }
-          60% { opacity: 0.6; }
-        }
-        @keyframes bipod-sway {
-          0%, 100% { transform: rotate(0deg); transform-origin: 35px 50px; }
-          50% { transform: rotate(2deg); transform-origin: 35px 50px; }
+        @keyframes bolt-fly {
+          0%, 73%, 100% { opacity: 1; transform: translateX(0); }
+          74% { opacity: 1; }
+          80% { opacity: 0; transform: translateX(60px); }
+          82%, 99% { opacity: 0; }
         }
       `}</style>
-      {/* Stock */}
-      <rect x="90" y="37" width="38" height="14" rx="4" fill="#6b3d1a" />
-      <rect x="90" y="38" width="38" height="4" rx="2" fill="#8b5a2a" opacity="0.4" />
-      {/* Cheekrest */}
-      <rect x="95" y="32" width="22" height="6" rx="3" fill="#7a4520" />
-      {/* Receiver */}
-      <rect x="52" y="35" width="42" height="16" rx="3" fill="#1e1e1e" />
-      {/* Magazine */}
-      <rect x="70" y="51" width="10" height="12" rx="2" fill="#222" />
-      {/* Grip */}
-      <polygon points="78,51 90,51 86,64 74,64" fill="#1a1a1a" />
-      {/* Trigger guard */}
-      <path d="M75 51 Q71 60 80 57" stroke="#444" strokeWidth="2" fill="none" strokeLinecap="round" />
-      {/* Barrel (long) */}
-      <rect x="6" y="38.5" width="50" height="8" rx="3" fill="#1a1a1a" />
-      {/* Muzzle brake / suppressor */}
-      <rect x="4" y="37.5" width="7" height="10" rx="2" fill="#2a2a2a" />
-      {/* Scope mount rail */}
-      <rect x="52" y="33" width="38" height="5" rx="1" fill="#2a2a2a" />
-      {/* Scope tube */}
-      <rect x="55" y="20" width="36" height="13" rx="6" fill="#333" />
-      <rect x="55" y="21" width="36" height="4" rx="3" fill="#444" opacity="0.5" />
-      {/* Scope objective (front) */}
-      <circle cx="60" cy="26.5" r="7" fill="#2a2a2a" />
-      <circle cx="60" cy="26.5" r="5.5" fill="#1a3a5a" />
-      <circle
-        cx="60" cy="26.5" r="4"
-        fill="#88ccff"
-        style={{ animation: "scope-lens-glow 2s ease-in-out infinite" }}
-      />
-      {/* Scope crosshair lines */}
-      <g style={{ animation: "scope-crosshair 2s ease-in-out infinite" }}>
-        <line x1="57" y1="26.5" x2="63" y2="26.5" stroke="white" strokeWidth="0.8" />
-        <line x1="60" y1="23.5" x2="60" y2="29.5" stroke="white" strokeWidth="0.8" />
-        <circle cx="60" cy="26.5" r="1.5" stroke="white" strokeWidth="0.6" fill="none" />
+
+      <g style={{ animation: "crossbow-recoil 4s ease-in-out infinite" }}>
+        {/* Stock */}
+        <rect x="72" y="36" width="52" height="14" rx="4" fill="#6b3d1a" />
+        <rect x="72" y="37" width="52" height="4" rx="2" fill="#8b5a2a" opacity="0.4" />
+        {/* Grip */}
+        <polygon points="88,50 100,50 96,64 84,64" fill="#2a1a08" />
+        {/* Trigger guard */}
+        <path d="M87 50 Q83 58 92 55" stroke="#555" strokeWidth="2" fill="none" strokeLinecap="round" />
+        {/* Trigger */}
+        <rect x="89" y="49" width="4" height="7" rx="1" fill="#666" />
+
+        {/* Tiller / rail */}
+        <rect x="22" y="37" width="54" height="8" rx="2" fill="#1a1a1a" />
+
+        {/* Horizontal bow limbs */}
+        <line x1="22" y1="41" x2="6" y2="30" stroke="#2a1a08" strokeWidth="6" strokeLinecap="round" />
+        <line x1="22" y1="41" x2="6" y2="52" stroke="#2a1a08" strokeWidth="6" strokeLinecap="round" />
+        {/* Limb tips */}
+        <circle cx="6" cy="30" r="3.5" fill="#1a0a04" />
+        <circle cx="6" cy="52" r="3.5" fill="#1a0a04" />
+
+        {/* Stirrup (metal loop at front) */}
+        <ellipse cx="18" cy="41" rx="6" ry="9" stroke="#444" strokeWidth="2.5" fill="none" />
+
+        {/* Bowstring */}
+        <g style={{ animation: "crossbow-string 4s ease-in-out infinite" }}>
+          <line x1="6" y1="30" x2="22" y2="41" stroke="#ddd0aa" strokeWidth="1.5" />
+          <line x1="6" y1="52" x2="22" y2="41" stroke="#ddd0aa" strokeWidth="1.5" />
+        </g>
+
+        {/* Loaded bolt */}
+        <g style={{ animation: "bolt-fly 4s ease-in-out infinite" }}>
+          <line x1="22" y1="40" x2="68" y2="40" stroke="#8b5e3c" strokeWidth="3.5" strokeLinecap="round" />
+          <polygon points="68,40 60,37 62,40 60,43" fill="#888888" />
+          {/* Bolt fletching */}
+          <polygon points="26,40 22,35 30,40" fill="#cc3333" opacity="0.8" />
+          <polygon points="26,40 22,45 30,40" fill="#cc3333" opacity="0.8" />
+        </g>
+
+        {/* Scope rail */}
+        <rect x="42" y="33" width="28" height="4" rx="1" fill="#2a2a2a" />
+        {/* Scope (small red dot) */}
+        <rect x="48" y="25" width="18" height="9" rx="4" fill="#333" />
+        <circle cx="57" cy="29.5" r="3" fill="#1a1a1a" />
+        <circle cx="57" cy="29.5" r="1.5" fill="#ff2222" opacity="0.8" />
+
+        {/* Highlight on stock */}
+        <rect x="72" y="37" width="52" height="2" rx="1" fill="white" opacity="0.07" />
       </g>
-      {/* Scope eyepiece (rear) */}
-      <circle cx="86" cy="26.5" r="5" fill="#2a2a2a" />
-      <circle cx="86" cy="26.5" r="3.5" fill="#1a2a3a" />
-      <circle cx="86" cy="26.5" r="2"
-        fill="#4488cc" opacity="0.8"
-        style={{ animation: "scope-pulse 2s ease-in-out infinite" }}
-      />
-      {/* Scope turret (elevation knob) */}
-      <rect x="70" y="13" width="5" height="10" rx="2" fill="#333" />
-      <rect x="70.5" y="14" width="4" height="2" rx="1" fill="#555" />
-      {/* Bipod */}
-      <g style={{ animation: "bipod-sway 3s ease-in-out infinite" }}>
-        <line x1="28" y1="46.5" x2="18" y2="62" stroke="#333" strokeWidth="2.5" strokeLinecap="round" />
-        <line x1="36" y1="46.5" x2="46" y2="62" stroke="#333" strokeWidth="2.5" strokeLinecap="round" />
-        {/* Bipod feet */}
-        <rect x="14" y="61" width="8" height="2.5" rx="1" fill="#2a2a2a" />
-        <rect x="42" y="61" width="8" height="2.5" rx="1" fill="#2a2a2a" />
-      </g>
-      {/* Highlight on barrel */}
-      <rect x="6" y="39" width="50" height="2" rx="1" fill="white" opacity="0.06" />
     </svg>
   );
 }
@@ -243,34 +242,34 @@ const WEAPON_META: Record<
     key: string;
   }
 > = {
-  pistol: {
-    icon: null,
-    stats: [
-      { label: "Poškození", value: 25, max: 100 },
-      { label: "Dostřel", value: 55, max: 100 },
-      { label: "Rychlost střelby", value: 75, max: 100 },
-    ],
-    description: "Spolehlivá standardní pistole. Dobrá rovnováha poškození a rychlosti.",
-    key: "1",
-  },
   sword: {
     icon: null,
     stats: [
       { label: "Poškození", value: 80, max: 100 },
-      { label: "Dostřel", value: 20, max: 100 },
-      { label: "Rychlost útoku", value: 95, max: 100 },
+      { label: "Dostřel", value: 15, max: 100 },
+      { label: "Rychlost útoku", value: 90, max: 100 },
     ],
-    description: "Ocelový meč pro boj zblízka. Žádné projektily — ale smrtící na krátkou vzdálenost.",
+    description: "Ocelový meč pro šermování zblízka. Rychlé výpady — žádné projektily, smrtící na krátkou vzdálenost.",
+    key: "1",
+  },
+  bow: {
+    icon: null,
+    stats: [
+      { label: "Poškození", value: 55, max: 100 },
+      { label: "Dostřel", value: 75, max: 100 },
+      { label: "Rychlost střelby", value: 60, max: 100 },
+    ],
+    description: "Dřevěný luk se šípy. Tichá střelba na střední vzdálenost — pomalé nabití, ale přesný zásah.",
     key: "2",
   },
-  sniper: {
+  crossbow: {
     icon: null,
     stats: [
       { label: "Poškození", value: 95, max: 100 },
       { label: "Dostřel", value: 100, max: 100 },
       { label: "Rychlost střelby", value: 25, max: 100 },
     ],
-    description: "Přesná puška s optickým zaměřovačem. Jeden výstřel stačí.",
+    description: "Kuše se šipkou. Ničivá síla na dálku — pomalé nabití, ale devastující průbojný bolt.",
     key: "3",
   },
 };
@@ -359,9 +358,9 @@ function WeaponCard({ type, selected, onSelect }: WeaponCardProps) {
           marginBottom: 12,
         }}
       >
-        {type === "pistol" && <PistolSVG selected={selected} />}
         {type === "sword" && <SwordSVG selected={selected} />}
-        {type === "sniper" && <SniperSVG selected={selected} />}
+        {type === "bow" && <BowSVG selected={selected} />}
+        {type === "crossbow" && <CrossbowSVG selected={selected} />}
       </div>
 
       {/* Name */}
@@ -439,14 +438,14 @@ interface WeaponSelectProps {
 }
 
 export default function WeaponSelect({ onConfirm }: WeaponSelectProps) {
-  const [selected, setSelected] = useState<WeaponType>("pistol");
+  const [selected, setSelected] = useState<WeaponType>("sword");
 
   // Keyboard shortcuts 1/2/3 to pick weapon, Enter to confirm
   React.useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "1") setSelected("pistol");
-      if (e.key === "2") setSelected("sword");
-      if (e.key === "3") setSelected("sniper");
+      if (e.key === "1") setSelected("sword");
+      if (e.key === "2") setSelected("bow");
+      if (e.key === "3") setSelected("crossbow");
       if (e.key === "Enter") onConfirm(selected);
     };
     window.addEventListener("keydown", handler);
@@ -502,7 +501,7 @@ export default function WeaponSelect({ onConfirm }: WeaponSelectProps) {
             marginBottom: 24,
           }}
         >
-          {(["pistol", "sword", "sniper"] as WeaponType[]).map((t) => (
+          {(["sword", "bow", "crossbow"] as WeaponType[]).map((t) => (
             <WeaponCard key={t} type={t} selected={selected === t} onSelect={setSelected} />
           ))}
         </div>

--- a/liquid-glass-clock/docs/weapon-system.md
+++ b/liquid-glass-clock/docs/weapon-system.md
@@ -1,0 +1,77 @@
+# Weapon System
+
+The game features three distinct weapons selectable before entering the world. Each has a unique combat style, 3D model, and procedurally synthesised audio.
+
+## Weapons
+
+| Key | Weapon | Czech | Type | Damage | Cooldown | Bullet Speed |
+|-----|--------|-------|------|--------|----------|--------------|
+| [1] | Sword | Meč | Melee only | 55 | 0.45s | — |
+| [2] | Bow | Luk | Ranged | 40 | 1.1s | 38 u/s |
+| [3] | Crossbow | Kuše | Ranged | 85 | 2.2s | 90 u/s |
+
+## Sword (Meč)
+
+- **Combat style:** Fencing / melee. No projectiles are spawned.
+- **Range:** 2.2 world units.
+- **3D model:** `buildSwordMesh()` — long blade with emissive glow, golden cross-guard, wrapped grip, pommel sphere.
+- **Sound:** `_playSwordSwing()` — sharp bandpass noise swish (2.4 kHz) + metallic sine ring (~920–1040 Hz).
+- **Special:** Only the sword can perform melee attacks against catapults (checked in `doAttack` via `weaponCfg.type === "sword"`).
+
+## Bow (Luk)
+
+- **Combat style:** Silent ranged. Fires arrow projectiles at moderate speed.
+- **Range:** 80 units (long).
+- **3D model:** `buildBowMesh()` — curved limbs in three segments, dark wood grip, bowstring, loaded arrow with fletching.
+- **Sound:** `_playBowShot()` — low-frequency bowstring twang (130 Hz + harmonic at 260 Hz) + high-pass noise whoosh (1.8 kHz) representing the arrow in flight.
+
+## Crossbow (Kuše)
+
+- **Combat style:** High-damage ranged. Fires bolt projectiles at high speed with long reload.
+- **Range:** 100 units (very long).
+- **3D model:** `buildCrossbowMesh()` — wooden stock with butt, metal rail/tiller, horizontal limbs, stirrup, drawn string, trigger guard, loaded bolt with tip.
+- **Sound:** `_playCrossbowShot()` — square wave mechanical trigger click (580 Hz) + deep sine thunk (210→70 Hz) + high-pass noise bolt release (3 kHz).
+
+## Architecture
+
+### Type System (`lib/gameTypes.ts`)
+
+```typescript
+export type WeaponType = "sword" | "bow" | "crossbow";
+
+export interface WeaponConfig {
+  type: WeaponType;
+  label: string;       // Czech display name
+  damage: number;
+  range: number;       // Melee range (0 = melee only) or max range for ranged
+  cooldown: number;    // Seconds between attacks
+  bulletSpeed: number; // 0 = melee-only; >0 = ranged projectile speed
+  color: string;       // CSS accent colour for UI
+}
+```
+
+### Selection UI (`components/WeaponSelect.tsx`)
+
+- Animated SVG previews for each weapon (idle animation, attack animation)
+- Czech descriptions and stat bars per weapon
+- Keyboard shortcuts: [1] Sword, [2] Bow, [3] Crossbow, [Enter] confirm
+
+### 3D Models (`lib/meshBuilders.ts`)
+
+| Function | Weapon |
+|----------|--------|
+| `buildSwordMesh()` | Sword |
+| `buildBowMesh()` | Bow |
+| `buildCrossbowMesh()` | Crossbow |
+
+### Sound (`lib/soundManager.ts`)
+
+`playAttack(weaponType: string)` dispatches to one of three private synthesis methods based on the weapon type. All sounds are procedurally generated via the Web Audio API.
+
+### Game Loop (`components/Game3D.tsx`)
+
+- **`swapWeaponMesh(type)`** — replaces the camera-parented weapon group when switching.
+- **`doAttack()`** — calls `soundManager.playAttack(weaponCfg.type)`, spawns projectile if `bulletSpeed > 0`, checks melee range for immediate hits.
+- **Weapon sway** — per-weapon base position constants for idle sway animation.
+- **HUD** — weapon slots show emoji (⚔️ 🏹 🎯) with active weapon highlighted.
+- **Scroll wheel / [1][2][3]** — cycle or select weapons during gameplay.

--- a/liquid-glass-clock/lib/gameTypes.ts
+++ b/liquid-glass-clock/lib/gameTypes.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 
 // ─── Weapon system ────────────────────────────────────────────────────────────
-export type WeaponType = "pistol" | "sword" | "sniper";
+export type WeaponType = "sword" | "bow" | "crossbow";
 
 export interface WeaponConfig {
   type: WeaponType;
@@ -20,31 +20,31 @@ export interface WeaponConfig {
 }
 
 export const WEAPON_CONFIGS: Record<WeaponType, WeaponConfig> = {
-  pistol: {
-    type: "pistol",
-    label: "Pistole",
-    damage: 25,
-    range: 5,
-    cooldown: 0.65,
-    bulletSpeed: 55,
-    color: "#6ee7b7",
-  },
   sword: {
     type: "sword",
     label: "Meč",
-    damage: 50,
-    range: 4.5,
-    cooldown: 0.38,
-    bulletSpeed: 0, // melee only
+    damage: 55,
+    range: 2.2,
+    cooldown: 0.45,
+    bulletSpeed: 0, // melee only – šermování
     color: "#fbbf24",
   },
-  sniper: {
-    type: "sniper",
-    label: "Sniperka",
-    damage: 90,
-    range: 8,
-    cooldown: 2.0,
-    bulletSpeed: 130,
+  bow: {
+    type: "bow",
+    label: "Luk",
+    damage: 40,
+    range: 80,
+    cooldown: 1.1,
+    bulletSpeed: 38,
+    color: "#86efac",
+  },
+  crossbow: {
+    type: "crossbow",
+    label: "Kuše",
+    damage: 85,
+    range: 100,
+    cooldown: 2.2,
+    bulletSpeed: 90,
     color: "#f87171",
   },
 };

--- a/liquid-glass-clock/lib/meshBuilders.ts
+++ b/liquid-glass-clock/lib/meshBuilders.ts
@@ -960,6 +960,194 @@ export function buildSniperMesh(): THREE.Group {
   return group;
 }
 
+// ─── Weapon (bow) ─────────────────────────────────────────────────────────────
+/** First-person bow with curved limbs and a visible string. */
+export function buildBowMesh(): THREE.Group {
+  const group = new THREE.Group();
+  const woodMat = new THREE.MeshLambertMaterial({ color: 0x7a4a1a });
+  const darkWoodMat = new THREE.MeshLambertMaterial({ color: 0x4a2a08 });
+  const stringMat = new THREE.MeshLambertMaterial({ color: 0xeeddbb });
+  const arrowMat = new THREE.MeshLambertMaterial({ color: 0x8b5e3c });
+  const arrowTipMat = new THREE.MeshLambertMaterial({ color: 0xaaaaaa });
+  const fletchingMat = new THREE.MeshLambertMaterial({ color: 0xdd4444 });
+
+  // ── Grip (center handle) ─────────────────────────────────────────────────
+  const gripGeo = new THREE.CylinderGeometry(0.016, 0.018, 0.14, 8);
+  const grip = new THREE.Mesh(gripGeo, darkWoodMat);
+  group.add(grip);
+
+  // ── Upper limb (curved upward arc – 3 segments) ──────────────────────────
+  // Segment 1: lower part of upper limb
+  const u1Geo = new THREE.CylinderGeometry(0.012, 0.015, 0.10, 7);
+  const u1 = new THREE.Mesh(u1Geo, woodMat);
+  u1.position.set(0.018, 0.115, 0.01);
+  u1.rotation.z = 0.22;
+  group.add(u1);
+
+  // Segment 2: mid upper limb
+  const u2Geo = new THREE.CylinderGeometry(0.009, 0.012, 0.10, 7);
+  const u2 = new THREE.Mesh(u2Geo, woodMat);
+  u2.position.set(0.042, 0.21, 0.008);
+  u2.rotation.z = 0.48;
+  group.add(u2);
+
+  // Segment 3: tip of upper limb (angled back toward string)
+  const u3Geo = new THREE.CylinderGeometry(0.006, 0.009, 0.07, 6);
+  const u3 = new THREE.Mesh(u3Geo, woodMat);
+  u3.position.set(0.074, 0.28, 0.002);
+  u3.rotation.z = 0.72;
+  group.add(u3);
+
+  // ── Lower limb (mirrored) ─────────────────────────────────────────────────
+  const l1Geo = new THREE.CylinderGeometry(0.012, 0.015, 0.10, 7);
+  const l1 = new THREE.Mesh(l1Geo, woodMat);
+  l1.position.set(0.018, -0.115, 0.01);
+  l1.rotation.z = -0.22;
+  group.add(l1);
+
+  const l2Geo = new THREE.CylinderGeometry(0.009, 0.012, 0.10, 7);
+  const l2 = new THREE.Mesh(l2Geo, woodMat);
+  l2.position.set(0.042, -0.21, 0.008);
+  l2.rotation.z = -0.48;
+  group.add(l2);
+
+  const l3Geo = new THREE.CylinderGeometry(0.006, 0.009, 0.07, 6);
+  const l3 = new THREE.Mesh(l3Geo, woodMat);
+  l3.position.set(0.074, -0.28, 0.002);
+  l3.rotation.z = -0.72;
+  group.add(l3);
+
+  // ── Bowstring (thin flat box from upper to lower tip) ─────────────────────
+  const stringGeo = new THREE.BoxGeometry(0.004, 0.60, 0.003);
+  const stringMesh = new THREE.Mesh(stringGeo, stringMat);
+  stringMesh.position.set(0.095, 0, 0.0);
+  group.add(stringMesh);
+
+  // ── Arrow on the string ───────────────────────────────────────────────────
+  // Shaft
+  const shaftGeo = new THREE.CylinderGeometry(0.005, 0.005, 0.38, 6);
+  const shaft = new THREE.Mesh(shaftGeo, arrowMat);
+  shaft.rotation.x = Math.PI / 2;
+  shaft.position.set(0.06, 0, -0.12);
+  group.add(shaft);
+
+  // Arrowhead
+  const tipGeo = new THREE.ConeGeometry(0.009, 0.04, 6);
+  const tip = new THREE.Mesh(tipGeo, arrowTipMat);
+  tip.rotation.x = -Math.PI / 2;
+  tip.position.set(0.06, 0, -0.33);
+  group.add(tip);
+
+  // Fletching (two small flat rectangles at the nock end)
+  const fletchGeo = new THREE.BoxGeometry(0.002, 0.035, 0.05);
+  const fletch1 = new THREE.Mesh(fletchGeo, fletchingMat);
+  fletch1.position.set(0.066, 0.018, 0.08);
+  group.add(fletch1);
+  const fletch2 = new THREE.Mesh(fletchGeo.clone(), fletchingMat);
+  fletch2.position.set(0.066, -0.018, 0.08);
+  group.add(fletch2);
+
+  return group;
+}
+
+// ─── Weapon (crossbow) ────────────────────────────────────────────────────────
+/** First-person crossbow with stock, horizontal limbs and loaded bolt. */
+export function buildCrossbowMesh(): THREE.Group {
+  const group = new THREE.Group();
+  const bodyMat = new THREE.MeshLambertMaterial({ color: 0x2a1a08 });
+  const woodMat = new THREE.MeshLambertMaterial({ color: 0x6b3d1a });
+  const metalMat = new THREE.MeshLambertMaterial({ color: 0x3a3a3a });
+  const darkMetalMat = new THREE.MeshLambertMaterial({ color: 0x1a1a1a });
+  const stringMat = new THREE.MeshLambertMaterial({ color: 0xddccaa });
+  const boltMat = new THREE.MeshLambertMaterial({ color: 0x7a4a1a });
+  const boltTipMat = new THREE.MeshLambertMaterial({ color: 0x888888 });
+
+  // ── Stock (main wooden body, aimed along -Z) ──────────────────────────────
+  const stockGeo = new THREE.BoxGeometry(0.06, 0.055, 0.40);
+  const stock = new THREE.Mesh(stockGeo, woodMat);
+  stock.position.set(0, 0, 0.02);
+  group.add(stock);
+
+  // Butt of the stock (wider end at back)
+  const buttGeo = new THREE.BoxGeometry(0.07, 0.065, 0.10);
+  const butt = new THREE.Mesh(buttGeo, woodMat);
+  butt.position.set(0, -0.004, 0.22);
+  group.add(butt);
+
+  // ── Tiller / rail (forward rail for the bolt to slide on) ─────────────────
+  const railGeo = new THREE.BoxGeometry(0.038, 0.022, 0.30);
+  const rail = new THREE.Mesh(railGeo, darkMetalMat);
+  rail.position.set(0, 0.038, -0.12);
+  group.add(rail);
+
+  // ── Horizontal bow limbs (perpendicular to aiming axis) ───────────────────
+  // Left limb
+  const leftLimbGeo = new THREE.CylinderGeometry(0.010, 0.013, 0.26, 7);
+  const leftLimb = new THREE.Mesh(leftLimbGeo, bodyMat);
+  leftLimb.rotation.z = Math.PI / 2;
+  leftLimb.position.set(-0.13, 0.028, -0.22);
+  group.add(leftLimb);
+
+  // Right limb
+  const rightLimbGeo = new THREE.CylinderGeometry(0.010, 0.013, 0.26, 7);
+  const rightLimb = new THREE.Mesh(rightLimbGeo, bodyMat);
+  rightLimb.rotation.z = Math.PI / 2;
+  rightLimb.position.set(0.13, 0.028, -0.22);
+  group.add(rightLimb);
+
+  // ── Stirrup (metal loop at front, used to cock the crossbow) ─────────────
+  const stirrupGeo = new THREE.TorusGeometry(0.028, 0.007, 6, 10, Math.PI);
+  const stirrup = new THREE.Mesh(stirrupGeo, metalMat);
+  stirrup.rotation.y = Math.PI / 2;
+  stirrup.position.set(0, 0.006, -0.35);
+  group.add(stirrup);
+
+  // ── Bowstring (horizontal, pulled back in cocked position) ────────────────
+  // Left string half
+  const lStringGeo = new THREE.BoxGeometry(0.003, 0.003, 0.14);
+  const lString = new THREE.Mesh(lStringGeo, stringMat);
+  lString.position.set(-0.065, 0.028, -0.14);
+  lString.rotation.y = 0.18;
+  group.add(lString);
+
+  // Right string half
+  const rStringGeo = new THREE.BoxGeometry(0.003, 0.003, 0.14);
+  const rString = new THREE.Mesh(rStringGeo, stringMat);
+  rString.position.set(0.065, 0.028, -0.14);
+  rString.rotation.y = -0.18;
+  group.add(rString);
+
+  // ── Trigger mechanism (simple block) ─────────────────────────────────────
+  const triggerGeo = new THREE.BoxGeometry(0.022, 0.032, 0.028);
+  const trigger = new THREE.Mesh(triggerGeo, metalMat);
+  trigger.position.set(0, -0.01, 0.06);
+  group.add(trigger);
+
+  // Trigger guard
+  const guardGeo = new THREE.TorusGeometry(0.022, 0.007, 5, 8, Math.PI);
+  const guard = new THREE.Mesh(guardGeo, metalMat);
+  guard.rotation.z = Math.PI / 2;
+  guard.rotation.y = Math.PI / 2;
+  guard.position.set(0, -0.038, 0.07);
+  group.add(guard);
+
+  // ── Loaded bolt (quarrel) on the rail ─────────────────────────────────────
+  const boltShaftGeo = new THREE.CylinderGeometry(0.006, 0.006, 0.22, 6);
+  const boltShaft = new THREE.Mesh(boltShaftGeo, boltMat);
+  boltShaft.rotation.x = Math.PI / 2;
+  boltShaft.position.set(0, 0.048, -0.14);
+  group.add(boltShaft);
+
+  // Bolt tip
+  const boltTipGeo = new THREE.ConeGeometry(0.010, 0.038, 6);
+  const boltTip = new THREE.Mesh(boltTipGeo, boltTipMat);
+  boltTip.rotation.x = -Math.PI / 2;
+  boltTip.position.set(0, 0.048, -0.27);
+  group.add(boltTip);
+
+  return group;
+}
+
 // ─── Lighthouse ───────────────────────────────────────────────────────────────
 export function buildLighthouse(): { group: THREE.Group; beamPivot: THREE.Group; lighthouseLight: THREE.PointLight } {
   const group = new THREE.Group();

--- a/liquid-glass-clock/lib/soundManager.ts
+++ b/liquid-glass-clock/lib/soundManager.ts
@@ -455,27 +455,154 @@ class SoundManager {
     osc.stop(t + dur);
   }
 
-  /** Sharp crack + whoosh for the player's ranged attack. */
-  playAttack(): void {
+  /**
+   * Weapon attack sound – different audio per weapon type.
+   * @param weaponType  "sword" | "bow" | "crossbow"
+   */
+  playAttack(weaponType: string = "bow"): void {
+    if (!this.ctx || !this.sfxGain) return;
+    if (weaponType === "sword") {
+      this._playSwordSwing();
+    } else if (weaponType === "crossbow") {
+      this._playCrossbowShot();
+    } else {
+      this._playBowShot();
+    }
+  }
+
+  /** Sword swing: sharp air-cutting swish + brief metallic ring. */
+  private _playSwordSwing(): void {
     if (!this.ctx || !this.sfxGain) return;
     const ctx = this.ctx;
     const t = ctx.currentTime;
 
-    // High-pass noise burst (muzzle noise)
-    this._noiseBurst(3200, "highpass", 0.25, 0.07);
+    // Swish – bandpass noise, fast decay, mimics blade cutting air
+    const swishSrc = ctx.createBufferSource();
+    swishSrc.buffer = this._noiseBuffer(0.18);
+    const swishFlt = ctx.createBiquadFilter();
+    swishFlt.type = "bandpass";
+    swishFlt.frequency.value = 2400;
+    swishFlt.Q.value = 0.7;
+    const swishEnv = ctx.createGain();
+    swishEnv.gain.setValueAtTime(0, t);
+    swishEnv.gain.linearRampToValueAtTime(0.32, t + 0.02);
+    swishEnv.gain.exponentialRampToValueAtTime(0.0001, t + 0.16);
+    swishSrc.connect(swishFlt);
+    swishFlt.connect(swishEnv);
+    swishEnv.connect(this.sfxGain);
+    swishSrc.start(t);
+    swishSrc.stop(t + 0.18);
 
-    // Downward frequency sweep (crack)
-    const osc = ctx.createOscillator();
-    osc.type = "sawtooth";
-    osc.frequency.setValueAtTime(900, t);
-    osc.frequency.exponentialRampToValueAtTime(180, t + 0.1);
-    const env = ctx.createGain();
-    env.gain.setValueAtTime(0.38, t);
-    env.gain.exponentialRampToValueAtTime(0.0001, t + 0.12);
-    osc.connect(env);
-    env.connect(this.sfxGain);
-    osc.start(t);
-    osc.stop(t + 0.12);
+    // Metallic ring – sine at steel resonance frequency, longer decay
+    const ringOsc = ctx.createOscillator();
+    ringOsc.type = "sine";
+    ringOsc.frequency.setValueAtTime(920 + Math.random() * 120, t + 0.02);
+    const ringEnv = ctx.createGain();
+    ringEnv.gain.setValueAtTime(0.14, t + 0.02);
+    ringEnv.gain.exponentialRampToValueAtTime(0.0001, t + 0.28);
+    ringOsc.connect(ringEnv);
+    ringEnv.connect(this.sfxGain);
+    ringOsc.start(t + 0.02);
+    ringOsc.stop(t + 0.28);
+  }
+
+  /** Bow shot: bowstring twang + arrow whoosh in flight. */
+  private _playBowShot(): void {
+    if (!this.ctx || !this.sfxGain) return;
+    const ctx = this.ctx;
+    const t = ctx.currentTime;
+
+    // Bowstring twang – low-pitched pluck with a brief vibrato decay
+    const twangOsc = ctx.createOscillator();
+    twangOsc.type = "sine";
+    twangOsc.frequency.setValueAtTime(130 + Math.random() * 20, t);
+    twangOsc.frequency.exponentialRampToValueAtTime(90, t + 0.15);
+    const twangEnv = ctx.createGain();
+    twangEnv.gain.setValueAtTime(0.42, t);
+    twangEnv.gain.exponentialRampToValueAtTime(0.0001, t + 0.22);
+    twangOsc.connect(twangEnv);
+    twangEnv.connect(this.sfxGain);
+    twangOsc.start(t);
+    twangOsc.stop(t + 0.22);
+
+    // Second harmonic – adds body to the pluck
+    const twangOsc2 = ctx.createOscillator();
+    twangOsc2.type = "sine";
+    twangOsc2.frequency.setValueAtTime(260 + Math.random() * 20, t);
+    twangOsc2.frequency.exponentialRampToValueAtTime(180, t + 0.1);
+    const twangEnv2 = ctx.createGain();
+    twangEnv2.gain.setValueAtTime(0.18, t);
+    twangEnv2.gain.exponentialRampToValueAtTime(0.0001, t + 0.14);
+    twangOsc2.connect(twangEnv2);
+    twangEnv2.connect(this.sfxGain);
+    twangOsc2.start(t);
+    twangOsc2.stop(t + 0.14);
+
+    // Arrow whoosh – highpass noise sweep (arrow in flight)
+    const whooshSrc = ctx.createBufferSource();
+    whooshSrc.buffer = this._noiseBuffer(0.2);
+    const whooshFlt = ctx.createBiquadFilter();
+    whooshFlt.type = "highpass";
+    whooshFlt.frequency.value = 1800;
+    whooshFlt.Q.value = 0.5;
+    const whooshEnv = ctx.createGain();
+    whooshEnv.gain.setValueAtTime(0, t + 0.04);
+    whooshEnv.gain.linearRampToValueAtTime(0.18, t + 0.08);
+    whooshEnv.gain.exponentialRampToValueAtTime(0.0001, t + 0.24);
+    whooshSrc.connect(whooshFlt);
+    whooshFlt.connect(whooshEnv);
+    whooshEnv.connect(this.sfxGain);
+    whooshSrc.start(t + 0.04);
+    whooshSrc.stop(t + 0.28);
+  }
+
+  /** Crossbow shot: mechanical click/thunk + sharp bolt release. */
+  private _playCrossbowShot(): void {
+    if (!this.ctx || !this.sfxGain) return;
+    const ctx = this.ctx;
+    const t = ctx.currentTime;
+
+    // Mechanical trigger click – short square pulse
+    const clickOsc = ctx.createOscillator();
+    clickOsc.type = "square";
+    clickOsc.frequency.value = 580 + Math.random() * 80;
+    const clickEnv = ctx.createGain();
+    clickEnv.gain.setValueAtTime(0.28, t);
+    clickEnv.gain.exponentialRampToValueAtTime(0.0001, t + 0.04);
+    clickOsc.connect(clickEnv);
+    clickEnv.connect(this.sfxGain);
+    clickOsc.start(t);
+    clickOsc.stop(t + 0.04);
+
+    // Body thunk – deep sine thud (limb energy release)
+    const thunkOsc = ctx.createOscillator();
+    thunkOsc.type = "sine";
+    thunkOsc.frequency.setValueAtTime(210, t + 0.01);
+    thunkOsc.frequency.exponentialRampToValueAtTime(70, t + 0.1);
+    const thunkEnv = ctx.createGain();
+    thunkEnv.gain.setValueAtTime(0.38, t + 0.01);
+    thunkEnv.gain.exponentialRampToValueAtTime(0.0001, t + 0.12);
+    thunkOsc.connect(thunkEnv);
+    thunkEnv.connect(this.sfxGain);
+    thunkOsc.start(t + 0.01);
+    thunkOsc.stop(t + 0.12);
+
+    // Bolt flight – high-pass noise, sharp and cutting (faster than bow arrow)
+    const boltSrc = ctx.createBufferSource();
+    boltSrc.buffer = this._noiseBuffer(0.14);
+    const boltFlt = ctx.createBiquadFilter();
+    boltFlt.type = "highpass";
+    boltFlt.frequency.value = 3000;
+    boltFlt.Q.value = 0.8;
+    const boltEnv = ctx.createGain();
+    boltEnv.gain.setValueAtTime(0, t + 0.02);
+    boltEnv.gain.linearRampToValueAtTime(0.22, t + 0.04);
+    boltEnv.gain.exponentialRampToValueAtTime(0.0001, t + 0.16);
+    boltSrc.connect(boltFlt);
+    boltFlt.connect(boltEnv);
+    boltEnv.connect(this.sfxGain);
+    boltSrc.start(t + 0.02);
+    boltSrc.stop(t + 0.18);
   }
 
   /** Impact thud played when a bullet / melee hit lands on a fox. */


### PR DESCRIPTION
## Summary

All 167 weapon-related tests pass and the commit is done. Here's a summary of what was implemented:

**Weapons replaced:** `pistol / sword / sniper` → `sword (Meč) / bow (Luk) / crossbow (Kuše)` in that order.

**Per-weapon sounds** added via Web Audio API synthesis: sword gets a blade-cutting bandpass noise swish plus a metallic sine ring; bow gets a low-frequency bowstring twang with harmonics plus a high-pass whoosh for the arrow in flight; crossbow gets a mechanical square-wave trigger click, a deep sine thunk from limb energy release, and a sharp high-pass noise bolt flight.

**New 3D models** `buildBowMesh()` and `buildCrossbowMesh()` were added to `meshBuilders.ts`, the weapon selection UI in `WeaponSelect.tsx` was updated with animated SVG previews for all three weapons, and all Game3D.tsx references (mesh swapping, sway positions, HUD, keyboard shortcuts) were updated to match the new weapon types.

## Commits

- feat: replace weapons with sword, bow, crossbow (meč, luk, kuše)