### PR TITLE
Pri k natahovani luku jeste to aby se vykresliil oblouk kudy sip poleti, aby se to dalo lepe odhadnout... zkratka chci a

### DIFF
--- a/liquid-glass-clock/__tests__/bowMechanics.test.ts
+++ b/liquid-glass-clock/__tests__/bowMechanics.test.ts
@@ -41,6 +41,42 @@ function calcArrowDamage(power: number | undefined): number {
     : baseDmg;
 }
 
+/** Downward acceleration applied to arrows — must match ARROW_GRAVITY in Game3D.tsx. */
+const ARROW_GRAVITY = -22;
+
+/**
+ * Simulate the bow trajectory arc the same way the game loop does:
+ * returns an array of 3D positions for `numPoints` steps each `dt` seconds apart.
+ * Stops early (and fills remaining slots with the landing point) if the simulated
+ * arrow would drop below `groundY` (default 0 for flat-ground tests).
+ */
+function simulateTrajectoryArc(
+  startPos: THREE.Vector3,
+  velocity: THREE.Vector3,
+  numPoints: number,
+  dt: number,
+  groundY = 0,
+): { points: THREE.Vector3[]; landIndex: number } {
+  const vel = velocity.clone();
+  const pos = startPos.clone();
+  const points: THREE.Vector3[] = [];
+  let landIndex = numPoints;
+
+  for (let i = 0; i < numPoints; i++) {
+    points.push(pos.clone());
+
+    if (i > 0 && pos.y <= groundY + 0.05) {
+      landIndex = i + 1;
+      break;
+    }
+
+    vel.y += ARROW_GRAVITY * dt;
+    pos.addScaledVector(vel, dt);
+  }
+
+  return { points, landIndex };
+}
+
 // ── BulletData interface ──────────────────────────────────────────────────────
 
 describe("BulletData interface – new fields", () => {
@@ -152,6 +188,75 @@ describe("calcArrowDamage – damage scales with draw power", () => {
     for (let i = 1; i < powers.length; i++) {
       expect(calcArrowDamage(powers[i])).toBeGreaterThanOrEqual(calcArrowDamage(powers[i - 1]));
     }
+  });
+});
+
+// ── Trajectory arc simulation ─────────────────────────────────────────────────
+
+describe("simulateTrajectoryArc – predicted arrow path", () => {
+  const TRAJ_DT = 0.06;
+  const NUM_POINTS = 80;
+
+  it("first point equals the start position", () => {
+    const start = new THREE.Vector3(0, 5, 0);
+    const vel = new THREE.Vector3(0, 0, -38); // horizontal full-power shot
+    const { points } = simulateTrajectoryArc(start, vel, NUM_POINTS, TRAJ_DT);
+    expect(points[0].x).toBeCloseTo(start.x);
+    expect(points[0].y).toBeCloseTo(start.y);
+    expect(points[0].z).toBeCloseTo(start.z);
+  });
+
+  it("arc curves downward due to gravity", () => {
+    const start = new THREE.Vector3(0, 10, 0);
+    const vel = new THREE.Vector3(0, 0, -38);
+    const { points } = simulateTrajectoryArc(start, vel, NUM_POINTS, TRAJ_DT);
+    // After enough steps the arrow must be lower than the start
+    const lastPoint = points[points.length - 1];
+    expect(lastPoint.y).toBeLessThan(start.y);
+  });
+
+  it("stops early when arrow reaches ground level", () => {
+    const start = new THREE.Vector3(0, 2, 0); // low start – hits ground quickly
+    const vel = new THREE.Vector3(0, 0, -38);
+    const { landIndex } = simulateTrajectoryArc(start, vel, NUM_POINTS, TRAJ_DT, 0);
+    expect(landIndex).toBeLessThan(NUM_POINTS);
+  });
+
+  it("upward-angled shot stays airborne longer than flat shot", () => {
+    const start = new THREE.Vector3(0, 5, 0);
+    const speed = 38;
+    const angle = Math.PI / 8; // 22.5° upward
+
+    const flatVel = new THREE.Vector3(0, 0, -speed);
+    const angledVel = new THREE.Vector3(0, Math.sin(angle) * speed, -Math.cos(angle) * speed);
+
+    const { landIndex: flatLand } = simulateTrajectoryArc(start, flatVel, NUM_POINTS, TRAJ_DT, 0);
+    const { landIndex: angledLand } = simulateTrajectoryArc(start, angledVel, NUM_POINTS, TRAJ_DT, 0);
+
+    expect(angledLand).toBeGreaterThan(flatLand);
+  });
+
+  it("weak shot (15% speed) lands much closer than full-power shot", () => {
+    const baseSpeed = WEAPON_CONFIGS.bow.bulletSpeed;
+    const start = new THREE.Vector3(0, 5, 0);
+
+    const weakVel = new THREE.Vector3(0, 0, -(baseSpeed * 0.15));
+    const fullVel  = new THREE.Vector3(0, 0, -baseSpeed);
+
+    const { points: weakPoints, landIndex: wi } = simulateTrajectoryArc(start, weakVel, NUM_POINTS, TRAJ_DT, 0);
+    const { points: fullPoints, landIndex: fi } = simulateTrajectoryArc(start, fullVel, NUM_POINTS, TRAJ_DT, 0);
+
+    const weakRange = Math.abs(weakPoints[wi - 1].z - start.z);
+    const fullRange  = Math.abs(fullPoints[fi - 1].z - start.z);
+    expect(fullRange).toBeGreaterThan(weakRange);
+  });
+
+  it("returns at most NUM_POINTS points even when arrow never hits ground", () => {
+    // Very high start + upward velocity — never reaches groundY = -9999
+    const start = new THREE.Vector3(0, 1000, 0);
+    const vel = new THREE.Vector3(0, 100, -38);
+    const { points } = simulateTrajectoryArc(start, vel, NUM_POINTS, TRAJ_DT, -9999);
+    expect(points.length).toBeLessThanOrEqual(NUM_POINTS);
   });
 });
 

--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -342,6 +342,8 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
   const bowChargeBarRef = useRef<HTMLDivElement | null>(null);
   /** Maximum hold time (seconds) to reach full power. */
   const BOW_MAX_CHARGE_TIME = 1.5;
+  /** THREE.Line that shows the predicted arrow trajectory arc while drawing. */
+  const trajectoryArcRef = useRef<THREE.Line | null>(null);
 
   // ─── Weapon / Bullet Refs ───────────────────────────────────────────────────
   const bulletsRef = useRef<BulletData[]>([]);
@@ -1056,6 +1058,27 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     muzzleFlash.position.set(WEAPON_POS.x, WEAPON_POS.y + 0.01, WEAPON_POS.z - 0.25);
     camera.add(muzzleFlash);
     muzzleFlashRef.current = muzzleFlash;
+
+    // ── Bow trajectory arc preview line ─────────────────────────────────────
+    // Pre-allocated geometry for up to TRAJ_ARC_POINTS steps; updated each frame
+    // while the bow is being drawn to give the player a trajectory preview.
+    const TRAJ_ARC_POINTS = 80;
+    const trajGeom = new THREE.BufferGeometry();
+    const trajPositions = new Float32Array(TRAJ_ARC_POINTS * 3);
+    trajGeom.setAttribute("position", new THREE.BufferAttribute(trajPositions, 3));
+    trajGeom.setDrawRange(0, 0); // hidden until needed
+    const trajMat = new THREE.LineDashedMaterial({
+      color: 0xffee66,
+      opacity: 0.80,
+      transparent: true,
+      dashSize: 0.45,
+      gapSize: 0.25,
+    });
+    const trajectoryArc = new THREE.Line(trajGeom, trajMat);
+    trajectoryArc.visible = false;
+    trajectoryArc.renderOrder = 999; // draw on top to stay visible
+    scene.add(trajectoryArc);
+    trajectoryArcRef.current = trajectoryArc;
 
     // ── Lighting ────────────────────────────────────────────────────────────
     const ambient = new THREE.AmbientLight(0xffffff, 0.45);
@@ -3740,6 +3763,55 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         }
       }
 
+      // ── Bow trajectory arc: simulate and render predicted arrow path ─────────
+      {
+        const arc = trajectoryArcRef.current;
+        const cam = cameraRef.current;
+        if (arc && cam && isBowChargingRef.current) {
+          const TRAJ_ARC_POINTS = 80;
+          const TRAJ_DT = 0.06; // seconds per simulation step
+
+          // Initial conditions matching doAttack() exactly
+          const startPos = new THREE.Vector3();
+          cam.getWorldPosition(startPos);
+          const fwd = new THREE.Vector3(0, 0, -1);
+          fwd.transformDirection(cam.matrixWorld);
+          startPos.addScaledVector(fwd, 1.2);
+
+          const power = bowChargeRef.current;
+          const effectiveSpeed = WEAPON_CONFIGS["bow"].bulletSpeed * Math.max(0.15, power);
+          const vel = fwd.clone().multiplyScalar(effectiveSpeed);
+          const pos = startPos.clone();
+
+          const positions = arc.geometry.attributes.position.array as Float32Array;
+          let endIndex = TRAJ_ARC_POINTS;
+
+          for (let i = 0; i < TRAJ_ARC_POINTS; i++) {
+            positions[i * 3]     = pos.x;
+            positions[i * 3 + 1] = pos.y;
+            positions[i * 3 + 2] = pos.z;
+
+            // Stop arc at terrain level
+            const groundY = getTerrainHeightSampled(pos.x, pos.z);
+            if (i > 0 && pos.y <= groundY + 0.05) {
+              endIndex = i + 1;
+              break;
+            }
+
+            // Advance physics (same as bullet update)
+            vel.y += ARROW_GRAVITY * TRAJ_DT;
+            pos.addScaledVector(vel, TRAJ_DT);
+          }
+
+          arc.geometry.setDrawRange(0, endIndex);
+          arc.geometry.attributes.position.needsUpdate = true;
+          arc.computeLineDistances(); // required for LineDashedMaterial
+          arc.visible = true;
+        } else if (arc) {
+          arc.visible = false;
+        }
+      }
+
       // ── Weapon sway & recoil animation ─────────────────────────────────────
       if (weaponMeshRef.current) {
         const wep = weaponMeshRef.current;
@@ -4838,6 +4910,13 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
       document.removeEventListener("pointerlockchange", onLockChange);
       window.removeEventListener("wheel", onWheel);
       window.removeEventListener("resize", onResize);
+      // Clean up trajectory arc
+      if (trajectoryArcRef.current) {
+        scene.remove(trajectoryArcRef.current);
+        trajectoryArcRef.current.geometry.dispose();
+        (trajectoryArcRef.current.material as THREE.LineDashedMaterial).dispose();
+        trajectoryArcRef.current = null;
+      }
       // Clean up any live bullets from the scene
       bulletsRef.current.forEach((b) => scene.remove(b.mesh));
       bulletsRef.current = [];


### PR DESCRIPTION
## Summary

Hotovo. Implementace:

- Při natahování luku (drženém levém tlačítku myši) se ve 3D světě zobrazí žluto-bílá přerušovaná čára — **oblouk** předpokládané trajektorie šípu.
- Oblouk se **aktualizuje každý snímek** a přesně reflektuje aktuální sílu natažení i směr míření. Fyzika (gravitace −22 j/s², rychlost ze `bulletSpeed × power`) je identická s reálným letem šípu, takže linie ukazuje přesně kam šíp doletí.
- Čára se zastaví na povrchu terénu a okamžitě zmizí po vystřelení. Přidáno 6 nových unit testů pokrývajících simulaci trajektorie — vše prošlo (25/25 testů).

## Commits

- feat: show trajectory arc preview while drawing bow