### PR TITLE
V noci nevidim zadny mesic nikde, a ve dne slunce. Oprav... udelej, aby se to krasne menilo a posouvalo mezi dnem a noci

### DIFF
--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -312,6 +312,9 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
   // Sun visuals
   const sunDiscRef = useRef<THREE.Mesh | null>(null);
   const sunCoronaRef = useRef<THREE.Mesh | null>(null);
+  // Moon visuals
+  const moonDiscRef = useRef<THREE.Mesh | null>(null);
+  const moonGlowRef = useRef<THREE.Mesh | null>(null);
   const cloudsRef = useRef<Array<{ mesh: THREE.Group; vx: number; vz: number }>>([]);
   const grassMatRef = useRef<THREE.ShaderMaterial | null>(null);
   const waterMatRef = useRef<THREE.ShaderMaterial | null>(null);
@@ -1162,6 +1165,28 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     scene.add(sunCorona);
     sunCoronaRef.current = sunCorona;
 
+    // ── Visible moon disc ────────────────────────────────────────────────────
+    const moonDiscGeo = new THREE.SphereGeometry(7, 24, 24);
+    const moonDiscMat = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(0.88, 0.92, 1.0), // cool white with slight blue tint
+      transparent: true,
+      opacity: 0.0,
+    });
+    const moonDisc = new THREE.Mesh(moonDiscGeo, moonDiscMat);
+    scene.add(moonDisc);
+    moonDiscRef.current = moonDisc;
+
+    // Moon glow halo — soft blue-white corona around the moon
+    const moonGlowGeo = new THREE.SphereGeometry(18, 16, 16);
+    const moonGlowMat = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(0.55, 0.65, 1.0), // diffuse blue-white
+      transparent: true,
+      opacity: 0.0,
+      depthWrite: false,
+    });
+    const moonGlow = new THREE.Mesh(moonGlowGeo, moonGlowMat);
+    scene.add(moonGlow);
+    moonGlowRef.current = moonGlow;
 
     // ── Stars ───────────────────────────────────────────────────────────────
     const starPositions: number[] = [];
@@ -2948,6 +2973,24 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         moonRef.current.intensity =
           smoothstep(0.82, 0.9, dayFraction) * 0.35 +
           smoothstep(0.18, 0.1, dayFraction) * 0.35;
+
+        // ── Visible moon disc + glow ─────────────────────────────────────────
+        if (moonDiscRef.current && moonGlowRef.current) {
+          const moonDir = moonRef.current.position.clone().normalize();
+          moonDiscRef.current.position.copy(moonDir.multiplyScalar(450));
+          moonGlowRef.current.position.copy(moonDir.multiplyScalar(448));
+
+          // Fade moon in/out with night factor (1=night, 0=day)
+          const moonOpacity = nightFactor;
+          const moonDiscMat = moonDiscRef.current.material as THREE.MeshBasicMaterial;
+          const moonGlowMat = moonGlowRef.current.material as THREE.MeshBasicMaterial;
+
+          moonDiscRef.current.visible = moonOpacity > 0.01;
+          moonGlowRef.current.visible = moonOpacity > 0.01;
+          moonDiscMat.opacity = moonOpacity;
+          // Subtle pulse on glow (slower than sun corona)
+          moonGlowMat.opacity = moonOpacity * (0.06 + Math.sin(elapsed * 0.25) * 0.015);
+        }
       }
 
       if (ambientRef.current) {


### PR DESCRIPTION
## Summary

Use Playwright to take screenshots of the 3D game at http://da7219674f1b:3000 to verify the day/night cycle. 

Steps:
1. Navigate to the page
2. If there's a lobby screen (input for player name), enter a name like "TestPlayer" and submit
3. Wait for the 3D game to load (wait for canvas element)
4. Take a screenshot
5. The game has a day/night cycle with DAY_DURATION=300 seconds. The game starts at dayFraction=0.3 (daytime). To see the night and moon, we need to wait or manipulate time.

Actually, just take a screenshot after loading to see the current state. Then try to manipulate the dayTimeRef via browser console to force night time.

Use this script:
```javascript
const { chromium } = require('playwright');
(async () => {
  const browser = await chromium.launch({ args: ['--no-sandbox'] });
  const page = await browser.newPage();
  page.setDefaultTimeout(30000);
  await page.goto('http://da7219674f1b:3000');
  await page.waitForTimeout(2000);
  
  // Enter player name if lobby is shown
  const input = await page.$('input[type="text"]');
  if (input) {
    await input.fill('TestPlayer');
    await page.keyboard.press('Enter');
    await page.waitForTimeout(3000);
  }
  
  // Take daytime screenshot
  await page.screenshot({ path: '/tmp/daytime.png', fullPage: false });
  console.log('Daytime screenshot taken');
  
  // Try to force night time by manipulating game state via console
  // We'll inject a script to fast-forward time
  await page.evaluate(() => {
    // Look for React fiber to access component state
    // Alternative: just wait and see
  });
  
  await browser.close();
})().catch(console.error);
```

Run this with node to take screenshots. Save screenshots to /tmp/.

## Commits

- feat(3d): add visible moon disc and glow halo for night cycle
- fix: correct rocket flight physics and add 1st/3rd person camera during flight
- fix: start bow trajectory arc from bow mesh position instead of camera center
- feat: add rideable rocket with launch sequence leading to the Mothership