### PR TITLE
luk a kuse nefunguji spravne. Sprav je, at s nimi muzu strilet na ostatni a at je to spravne zasahuje. Ted kuse proste t

### DIFF
--- a/liquid-glass-clock/__tests__/sheepCombat.test.ts
+++ b/liquid-glass-clock/__tests__/sheepCombat.test.ts
@@ -258,3 +258,66 @@ describe("Possession eligibility", () => {
     expect(candidates[0]).toBe(healthy);
   });
 });
+
+// ─── Ranged weapons use projectile collision only (not melee) ─────────────────
+
+/**
+ * These tests document the fix for the bug where bow and crossbow were
+ * incorrectly applying instant melee damage to the nearest entity on attack,
+ * ignoring where the player was actually aiming.
+ *
+ * After the fix: only weapons with type === "sword" apply melee damage in
+ * doAttack(). Bow and crossbow deal damage exclusively through bullet collision.
+ */
+describe("Ranged weapons do not apply melee damage in doAttack()", () => {
+  /**
+   * Simulate the melee targeting logic from doAttack() but limited to
+   * sword-only, mirroring the fixed implementation.
+   */
+  function simulateMeleeHit(
+    weaponType: "sword" | "bow" | "crossbow",
+    entityDistance: number,
+  ): boolean {
+    const cfg = WEAPON_CONFIGS[weaponType];
+    // Only sword should perform melee hits
+    if (cfg.type !== "sword") return false;
+    // Check if entity is within melee range
+    return entityDistance < cfg.range;
+  }
+
+  it("sword within melee range hits via melee", () => {
+    expect(simulateMeleeHit("sword", 1.5)).toBe(true);
+  });
+
+  it("sword beyond melee range does NOT hit via melee", () => {
+    expect(simulateMeleeHit("sword", 3.0)).toBe(false);
+  });
+
+  it("bow does NOT apply melee hit regardless of distance", () => {
+    // Even at point-blank range, bow should use projectile collision only
+    expect(simulateMeleeHit("bow", 0.5)).toBe(false);
+    expect(simulateMeleeHit("bow", 50)).toBe(false);
+  });
+
+  it("crossbow does NOT apply melee hit regardless of distance", () => {
+    // Even at point-blank range, crossbow should use projectile collision only
+    expect(simulateMeleeHit("crossbow", 0.5)).toBe(false);
+    expect(simulateMeleeHit("crossbow", 50)).toBe(false);
+  });
+
+  it("bow range is large (projectile range) but does not grant melee damage", () => {
+    // bow.range = 80 — was incorrectly used as melee range before the fix
+    const bowRange = WEAPON_CONFIGS.bow.range;
+    expect(bowRange).toBeGreaterThan(10);
+    // Despite large range, melee hit should not trigger
+    expect(simulateMeleeHit("bow", bowRange - 1)).toBe(false);
+  });
+
+  it("crossbow range is large (projectile range) but does not grant melee damage", () => {
+    // crossbow.range = 100 — was incorrectly used as melee range before the fix
+    const crossbowRange = WEAPON_CONFIGS.crossbow.range;
+    expect(crossbowRange).toBeGreaterThan(10);
+    // Despite large range, melee hit should not trigger
+    expect(simulateMeleeHit("crossbow", crossbowRange - 1)).toBe(false);
+  });
+});

--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -912,34 +912,36 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
       });
     }
 
-    // ── Melee hit (sword always; ranged weapons also hit if close enough) ───
+    // ── Melee hit (sword only — ranged weapons deal damage through projectile collision) ───
     const playerPos = cam.position;
-    let closest: (typeof foxListRef.current)[0] | null = null;
-    let closestDist = weaponCfg.range;
+    if (weaponCfg.type === "sword") {
+      let closest: (typeof foxListRef.current)[0] | null = null;
+      let closestDist = weaponCfg.range;
 
-    foxListRef.current.forEach((fox) => {
-      if (!fox.isAlive) return;
-      const d = fox.mesh.position.distanceTo(playerPos);
-      if (d < closestDist) {
-        closestDist = d;
-        closest = fox;
-      }
-    });
+      foxListRef.current.forEach((fox) => {
+        if (!fox.isAlive) return;
+        const d = fox.mesh.position.distanceTo(playerPos);
+        if (d < closestDist) {
+          closestDist = d;
+          closest = fox;
+        }
+      });
 
-    if (closest) {
-      const fox = closest as (typeof foxListRef.current)[0];
-      fox.hp = Math.max(0, fox.hp - weaponCfg.damage);
-      fox.hitFlashTimer = 0.25;
-      flashFoxMesh(fox.mesh);
-      soundManager.playFoxHit();
+      if (closest) {
+        const fox = closest as (typeof foxListRef.current)[0];
+        fox.hp = Math.max(0, fox.hp - weaponCfg.damage);
+        fox.hitFlashTimer = 0.25;
+        flashFoxMesh(fox.mesh);
+        soundManager.playFoxHit();
 
-      setAttackEffect(`-${weaponCfg.damage}`);
-      setTimeout(() => setAttackEffect(null), 700);
+        setAttackEffect(`-${weaponCfg.damage}`);
+        setTimeout(() => setAttackEffect(null), 700);
 
-      if (fox.hp <= 0) {
-        fox.isAlive = false;
-        foxesDefeatedRef.current++;
-        soundManager.playFoxDeath();
+        if (fox.hp <= 0) {
+          fox.isAlive = false;
+          foxesDefeatedRef.current++;
+          soundManager.playFoxDeath();
+        }
       }
     }
 
@@ -972,10 +974,9 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
       }
     }
 
-    // ── Melee hit on sheep ───────────────────────────────────────────────────
-    // Sheep can be hit with any weapon at melee range (same range as fox check)
+    // ── Melee hit on sheep (sword only — ranged weapons use projectile collision) ──
     if (!sceneRef.current) return;
-    {
+    if (weaponCfg.type === "sword") {
       let closestSheep: SheepData | null = null;
       let closestSheepDist = weaponCfg.range;
 


### PR DESCRIPTION
## Summary

Bug byl nalezen a opraven. V `doAttack()` se melee hit logika spouštěla pro **všechny zbraně** - problém byl, že luk má `range=80` a kuše `range=100`, takže každý výstřel okamžitě zasáhl nejbližší tvor do 100 jednotek vzdálenosti bez ohledu na míření. Melee kód byl obalení podmínkou `weaponCfg.type === "sword"`, takže luk a kuše nyní způsobují škodu **výhradně přes fyziku střely** - zasáhne jen to, na co hráč skutečně míří. Přidány testy ověřující toto chování.

## Commits

- fix: ranged weapons (bow/crossbow) now only deal damage via projectile collision