### PR TITLE
Implementuj chat mezi hraci

### DIFF
--- a/liquid-glass-clock/__tests__/ChatPanel.test.tsx
+++ b/liquid-glass-clock/__tests__/ChatPanel.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import ChatPanel from "../components/ChatPanel";
+import type { ChatMessage } from "../hooks/useMultiplayer";
+
+// Helper to build a minimal ChatMessage fixture.
+function makeMsg(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: "player-1",
+    name: "Alice",
+    color: 0x4a9eff,
+    text: "Ahoj!",
+    ts: Date.now(),
+    ...overrides,
+  };
+}
+
+// Default props for a quickly-rendered closed panel.
+const defaultProps = {
+  messages: [] as ChatMessage[],
+  onSend: jest.fn(),
+  isOpen: false,
+  onOpen: jest.fn(),
+  onClose: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+
+describe("ChatPanel — rendering", () => {
+  it("renders without crashing", () => {
+    expect(() => render(<ChatPanel {...defaultProps} />)).not.toThrow();
+  });
+
+  it("renders the chat-panel container", () => {
+    render(<ChatPanel {...defaultProps} />);
+    expect(screen.getByTestId("chat-panel")).toBeInTheDocument();
+  });
+
+  it("does not show the message log when there are no messages", () => {
+    render(<ChatPanel {...defaultProps} />);
+    expect(screen.queryByTestId("chat-message-log")).not.toBeInTheDocument();
+  });
+
+  it("does not show the input row when isOpen is false", () => {
+    render(<ChatPanel {...defaultProps} />);
+    expect(screen.queryByTestId("chat-input-row")).not.toBeInTheDocument();
+  });
+});
+
+// ─── Message display ──────────────────────────────────────────────────────────
+
+describe("ChatPanel — message display", () => {
+  it("shows the message log when messages are present", () => {
+    render(<ChatPanel {...defaultProps} messages={[makeMsg()]} />);
+    expect(screen.getByTestId("chat-message-log")).toBeInTheDocument();
+  });
+
+  it("renders each message with the sender name", () => {
+    const msgs = [
+      makeMsg({ name: "Alice", text: "Zdravím!" }),
+      makeMsg({ id: "player-2", name: "Bob", text: "Servus!", ts: Date.now() + 1 }),
+    ];
+    render(<ChatPanel {...defaultProps} messages={msgs} />);
+    expect(screen.getByText("Alice:")).toBeInTheDocument();
+    expect(screen.getByText("Bob:")).toBeInTheDocument();
+  });
+
+  it("renders message text", () => {
+    render(<ChatPanel {...defaultProps} messages={[makeMsg({ text: "Test zpráva" })]} />);
+    expect(screen.getByText("Test zpráva")).toBeInTheDocument();
+  });
+
+  it("renders all individual message elements", () => {
+    const msgs = Array.from({ length: 3 }, (_, i) =>
+      makeMsg({ id: `p-${i}`, name: `Player${i}`, ts: Date.now() + i })
+    );
+    render(<ChatPanel {...defaultProps} messages={msgs} />);
+    expect(screen.getAllByTestId("chat-message")).toHaveLength(3);
+  });
+
+  it("only shows last VISIBLE_COUNT (8) messages", () => {
+    const msgs = Array.from({ length: 12 }, (_, i) =>
+      makeMsg({ id: `p-${i}`, name: `P${i}`, text: `msg${i}`, ts: Date.now() + i })
+    );
+    render(<ChatPanel {...defaultProps} messages={msgs} />);
+    // ChatPanel shows at most 8 at a time
+    expect(screen.getAllByTestId("chat-message").length).toBeLessThanOrEqual(8);
+  });
+});
+
+// ─── Input / open state ───────────────────────────────────────────────────────
+
+describe("ChatPanel — input row", () => {
+  it("shows input row when isOpen is true", () => {
+    render(<ChatPanel {...defaultProps} isOpen={true} />);
+    expect(screen.getByTestId("chat-input-row")).toBeInTheDocument();
+  });
+
+  it("shows the text input when isOpen", () => {
+    render(<ChatPanel {...defaultProps} isOpen={true} />);
+    expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+  });
+
+  it("shows the send button when isOpen", () => {
+    render(<ChatPanel {...defaultProps} isOpen={true} />);
+    expect(screen.getByTestId("chat-send-button")).toBeInTheDocument();
+  });
+
+  it("send button is disabled when input is empty", () => {
+    render(<ChatPanel {...defaultProps} isOpen={true} />);
+    const btn = screen.getByTestId("chat-send-button");
+    expect(btn).toBeDisabled();
+  });
+
+  it("send button becomes enabled when user types a message", () => {
+    render(<ChatPanel {...defaultProps} isOpen={true} />);
+    fireEvent.change(screen.getByTestId("chat-input"), { target: { value: "Hi" } });
+    expect(screen.getByTestId("chat-send-button")).not.toBeDisabled();
+  });
+});
+
+// ─── Sending messages ─────────────────────────────────────────────────────────
+
+describe("ChatPanel — sending messages", () => {
+  it("calls onSend with the typed text when Enter is pressed", () => {
+    const onSend = jest.fn();
+    render(<ChatPanel {...defaultProps} isOpen={true} onSend={onSend} />);
+    fireEvent.change(screen.getByTestId("chat-input"), { target: { value: "Zdravím" } });
+    fireEvent.keyDown(screen.getByTestId("chat-input"), { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("Zdravím");
+  });
+
+  it("calls onClose after sending via Enter", () => {
+    const onClose = jest.fn();
+    render(<ChatPanel {...defaultProps} isOpen={true} onClose={onClose} />);
+    fireEvent.change(screen.getByTestId("chat-input"), { target: { value: "Hi" } });
+    fireEvent.keyDown(screen.getByTestId("chat-input"), { key: "Enter" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onSend with the typed text when send button is clicked", () => {
+    const onSend = jest.fn();
+    render(<ChatPanel {...defaultProps} isOpen={true} onSend={onSend} />);
+    fireEvent.change(screen.getByTestId("chat-input"), { target: { value: "Servus" } });
+    fireEvent.click(screen.getByTestId("chat-send-button"));
+    expect(onSend).toHaveBeenCalledWith("Servus");
+  });
+
+  it("calls onClose after sending via button click", () => {
+    const onClose = jest.fn();
+    render(<ChatPanel {...defaultProps} isOpen={true} onClose={onClose} />);
+    fireEvent.change(screen.getByTestId("chat-input"), { target: { value: "Nazdar" } });
+    fireEvent.click(screen.getByTestId("chat-send-button"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not call onSend when input is only whitespace", () => {
+    const onSend = jest.fn();
+    render(<ChatPanel {...defaultProps} isOpen={true} onSend={onSend} />);
+    fireEvent.change(screen.getByTestId("chat-input"), { target: { value: "   " } });
+    fireEvent.keyDown(screen.getByTestId("chat-input"), { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("clears the input after sending", () => {
+    render(<ChatPanel {...defaultProps} isOpen={true} />);
+    const input = screen.getByTestId("chat-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Test" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(input.value).toBe("");
+  });
+
+  it("calls onClose (not onSend) when Escape is pressed", () => {
+    const onSend = jest.fn();
+    const onClose = jest.fn();
+    render(<ChatPanel {...defaultProps} isOpen={true} onSend={onSend} onClose={onClose} />);
+    fireEvent.change(screen.getByTestId("chat-input"), { target: { value: "Draft" } });
+    fireEvent.keyDown(screen.getByTestId("chat-input"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("limits input to 120 characters", () => {
+    render(<ChatPanel {...defaultProps} isOpen={true} />);
+    const input = screen.getByTestId("chat-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "A".repeat(130) } });
+    expect(input.value).toHaveLength(120);
+  });
+});
+
+// ─── Unread badge ─────────────────────────────────────────────────────────────
+
+describe("ChatPanel — unread badge", () => {
+  it("does not show unread badge initially", () => {
+    render(<ChatPanel {...defaultProps} />);
+    expect(screen.queryByTestId("chat-unread-badge")).not.toBeInTheDocument();
+  });
+
+  it("shows unread badge when new messages arrive while closed", () => {
+    const { rerender } = render(<ChatPanel {...defaultProps} isOpen={false} />);
+    rerender(
+      <ChatPanel {...defaultProps} isOpen={false} messages={[makeMsg()]} />
+    );
+    expect(screen.getByTestId("chat-unread-badge")).toBeInTheDocument();
+  });
+
+  it("calls onOpen when unread badge is clicked", () => {
+    const onOpen = jest.fn();
+    const { rerender } = render(
+      <ChatPanel {...defaultProps} isOpen={false} onOpen={onOpen} />
+    );
+    rerender(
+      <ChatPanel
+        {...defaultProps}
+        isOpen={false}
+        onOpen={onOpen}
+        messages={[makeMsg()]}
+      />
+    );
+    fireEvent.click(screen.getByTestId("chat-unread-badge"));
+    expect(onOpen).toHaveBeenCalled();
+  });
+
+  it("hides unread badge when panel is opened", () => {
+    const { rerender } = render(
+      <ChatPanel {...defaultProps} isOpen={false} messages={[makeMsg()]} />
+    );
+    rerender(
+      <ChatPanel {...defaultProps} isOpen={true} messages={[makeMsg()]} />
+    );
+    expect(screen.queryByTestId("chat-unread-badge")).not.toBeInTheDocument();
+  });
+});

--- a/liquid-glass-clock/components/ChatPanel.tsx
+++ b/liquid-glass-clock/components/ChatPanel.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  type KeyboardEvent,
+} from "react";
+import type { ChatMessage } from "@/hooks/useMultiplayer";
+
+/** How long a message stays fully visible before starting to fade (ms). */
+const MESSAGE_VISIBLE_MS = 6000;
+/** Fade-out duration (ms). */
+const MESSAGE_FADE_MS = 1500;
+/** Total lifespan of a message in the log (ms). */
+const MESSAGE_TTL_MS = MESSAGE_VISIBLE_MS + MESSAGE_FADE_MS;
+/** Maximum characters in a single message. */
+const MAX_MSG_LENGTH = 120;
+/** Number of recent messages shown in the floating log. */
+const VISIBLE_COUNT = 8;
+
+interface TrackedMessage extends ChatMessage {
+  /** Unix timestamp when the message was received (for fade-out). */
+  receivedAt: number;
+}
+
+interface ChatPanelProps {
+  /** All chat messages to display (last N will be shown). */
+  messages: ChatMessage[];
+  /** Called when the user submits a message. */
+  onSend: (text: string) => void;
+  /** Whether the chat input is currently open. */
+  isOpen: boolean;
+  /** Request to open the input (e.g. from parent key handler). */
+  onOpen: () => void;
+  /** Request to close the input (parent may want to re-lock pointer, etc.). */
+  onClose: () => void;
+}
+
+/**
+ * ChatPanel — floating in-game chat overlay.
+ *
+ * Features:
+ * - Colour-coded player names (using the player's hex colour)
+ * - Messages auto-fade after MESSAGE_TTL_MS milliseconds
+ * - Scrolls to the newest message when new ones arrive
+ * - Unread badge when new messages arrive while the panel is closed
+ * - Input accepts up to MAX_MSG_LENGTH characters, submitted with Enter / cancelled
+ *   with Escape
+ * - "Send" button as an alternative to pressing Enter
+ */
+export default function ChatPanel({
+  messages,
+  onSend,
+  isOpen,
+  onOpen,
+  onClose,
+}: ChatPanelProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [unreadCount, setUnreadCount] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const logRef = useRef<HTMLDivElement>(null);
+  const prevMsgCountRef = useRef(messages.length);
+
+  // Track when each message was received for auto-fade.
+  const [tracked, setTracked] = useState<TrackedMessage[]>([]);
+  // Force re-renders while messages are fading.
+  const [, setTick] = useState(0);
+  const tickTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // ── Sync incoming messages → tracked list ─────────────────────────────────
+  useEffect(() => {
+    const now = Date.now();
+    setTracked((prev) => {
+      // Only add truly new messages (by timestamp + sender id).
+      const prevKeys = new Set(prev.map((m) => `${m.id}-${m.ts}`));
+      const newOnes = messages
+        .filter((m) => !prevKeys.has(`${m.id}-${m.ts}`))
+        .map((m) => ({ ...m, receivedAt: now }));
+      if (newOnes.length === 0) return prev;
+      const merged = [...prev, ...newOnes];
+      // Keep only last 50 tracked messages.
+      return merged.length > 50 ? merged.slice(merged.length - 50) : merged;
+    });
+  }, [messages]);
+
+  // ── Prune expired messages & keep fade animation running ──────────────────
+  useEffect(() => {
+    tickTimerRef.current = setInterval(() => {
+      const now = Date.now();
+      setTracked((prev) => {
+        const alive = prev.filter((m) => now - m.receivedAt < MESSAGE_TTL_MS);
+        return alive.length !== prev.length ? alive : prev;
+      });
+      setTick((t) => t + 1);
+    }, 250);
+    return () => {
+      if (tickTimerRef.current) clearInterval(tickTimerRef.current);
+    };
+  }, []);
+
+  // ── Auto-scroll log to bottom when new messages arrive ────────────────────
+  useEffect(() => {
+    const log = logRef.current;
+    if (log) {
+      log.scrollTop = log.scrollHeight;
+    }
+  }, [tracked.length]);
+
+  // ── Unread count when panel is closed ─────────────────────────────────────
+  useEffect(() => {
+    const newCount = messages.length;
+    const delta = newCount - prevMsgCountRef.current;
+    prevMsgCountRef.current = newCount;
+    if (!isOpen && delta > 0) {
+      setUnreadCount((c) => c + delta);
+    }
+    if (isOpen) {
+      setUnreadCount(0);
+    }
+  }, [messages.length, isOpen]);
+
+  // ── Focus input when opened ────────────────────────────────────────────────
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 40);
+    }
+  }, [isOpen]);
+
+  // ── Send helpers ──────────────────────────────────────────────────────────
+  const handleSend = useCallback(() => {
+    const text = inputValue.trim();
+    if (text) onSend(text);
+    setInputValue("");
+    onClose();
+  }, [inputValue, onSend, onClose]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleSend();
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setInputValue("");
+        onClose();
+      }
+    },
+    [handleSend, onClose]
+  );
+
+  // ── Compute which messages to show & their opacity ────────────────────────
+  const visibleMessages = tracked.slice(-VISIBLE_COUNT);
+  const now = Date.now();
+
+  const hasContent = visibleMessages.length > 0 || isOpen;
+
+  return (
+    <div
+      data-testid="chat-panel"
+      style={{
+        position: "fixed",
+        bottom: hasContent ? 20 : -220,
+        left: 20,
+        zIndex: 65,
+        width: 380,
+        maxWidth: "calc(100vw - 40px)",
+        transition: "bottom 0.3s ease",
+        pointerEvents: isOpen ? "auto" : "none",
+        userSelect: isOpen ? "text" : "none",
+      }}
+    >
+      {/* ── Unread badge (shown when chat is closed and there are unread messages) */}
+      {!isOpen && unreadCount > 0 && (
+        <button
+          data-testid="chat-unread-badge"
+          onClick={onOpen}
+          style={{
+            position: "absolute",
+            bottom: "calc(100% + 8px)",
+            left: 0,
+            padding: "4px 12px",
+            borderRadius: 20,
+            background: "rgba(74,158,255,0.85)",
+            border: "1px solid rgba(74,158,255,0.9)",
+            color: "white",
+            fontSize: 12,
+            fontWeight: 700,
+            cursor: "pointer",
+            backdropFilter: "blur(8px)",
+            pointerEvents: "auto",
+            boxShadow: "0 2px 8px rgba(74,158,255,0.4)",
+            animation: "chatBadgePulse 1.5s ease-in-out infinite",
+          }}
+        >
+          {unreadCount} {unreadCount === 1 ? "nová zpráva" : "nové zprávy"}
+        </button>
+      )}
+
+      {/* ── Message log ───────────────────────────────────────────────────── */}
+      {visibleMessages.length > 0 && (
+        <div
+          ref={logRef}
+          data-testid="chat-message-log"
+          style={{
+            marginBottom: 6,
+            maxHeight: 180,
+            overflowY: "auto",
+            display: "flex",
+            flexDirection: "column",
+            gap: 3,
+            scrollbarWidth: "none",
+          }}
+        >
+          {visibleMessages.map((msg, i) => {
+            const age = now - msg.receivedAt;
+            const opacity =
+              age < MESSAGE_VISIBLE_MS
+                ? 1
+                : Math.max(
+                    0,
+                    1 - (age - MESSAGE_VISIBLE_MS) / MESSAGE_FADE_MS
+                  );
+            const colorHex = `#${msg.color.toString(16).padStart(6, "0")}`;
+            return (
+              <div
+                key={`${msg.id}-${msg.ts}-${i}`}
+                data-testid="chat-message"
+                style={{
+                  padding: "4px 10px",
+                  borderRadius: 8,
+                  background: "rgba(5,8,20,0.78)",
+                  border: "1px solid rgba(255,255,255,0.07)",
+                  backdropFilter: "blur(8px)",
+                  fontSize: 12,
+                  color: "rgba(255,255,255,0.88)",
+                  display: "flex",
+                  gap: 6,
+                  alignItems: "baseline",
+                  opacity,
+                  transition: "opacity 0.25s linear",
+                }}
+              >
+                <span
+                  style={{
+                    fontWeight: 700,
+                    color: colorHex,
+                    flexShrink: 0,
+                  }}
+                >
+                  {msg.name}:
+                </span>
+                <span style={{ wordBreak: "break-word" }}>{msg.text}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* ── Input row (shown when isOpen) ─────────────────────────────────── */}
+      {isOpen && (
+        <div
+          data-testid="chat-input-row"
+          style={{ display: "flex", gap: 6, alignItems: "center" }}
+        >
+          <input
+            ref={inputRef}
+            data-testid="chat-input"
+            type="text"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value.slice(0, MAX_MSG_LENGTH))}
+            onKeyDown={handleKeyDown}
+            placeholder="Zpráva… (Enter odešle, Esc zruší)"
+            maxLength={MAX_MSG_LENGTH}
+            style={{
+              flex: 1,
+              padding: "8px 12px",
+              borderRadius: 10,
+              background: "rgba(5,8,20,0.92)",
+              border: "1px solid rgba(74,158,255,0.5)",
+              color: "white",
+              fontSize: 13,
+              outline: "none",
+            }}
+          />
+          <button
+            data-testid="chat-send-button"
+            onClick={handleSend}
+            disabled={!inputValue.trim()}
+            style={{
+              padding: "8px 14px",
+              borderRadius: 10,
+              background: inputValue.trim()
+                ? "rgba(74,158,255,0.7)"
+                : "rgba(74,158,255,0.2)",
+              border: "1px solid rgba(74,158,255,0.5)",
+              color: "white",
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: inputValue.trim() ? "pointer" : "default",
+              transition: "background 0.15s",
+              flexShrink: 0,
+            }}
+          >
+            Odeslat
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── CSS keyframe injected at module level ──────────────────────────────────────
+// (Inline styles can't use @keyframes; we inject a <style> tag once.)
+if (typeof document !== "undefined") {
+  const STYLE_ID = "__chat-panel-styles__";
+  if (!document.getElementById(STYLE_ID)) {
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      @keyframes chatBadgePulse {
+        0%, 100% { transform: scale(1); }
+        50% { transform: scale(1.05); }
+      }
+    `;
+    document.head.appendChild(style);
+  }
+}

--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -77,6 +77,7 @@ import {
 import { useMultiplayer, type PlayerUpdate } from "@/hooks/useMultiplayer";
 import WeaponSelect from "./WeaponSelect";
 import MobileControls from "./MobileControls";
+import ChatPanel from "./ChatPanel";
 
 // ─── Mobile detection ────────────────────────────────────────────────────────
 // Evaluated once at module initialisation on the client.  Returns false during
@@ -556,9 +557,7 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
 
   // ─── Chat state ──────────────────────────────────────────────────────────────
   const [chatMessages, setChatMessages] = useState<Array<{ id: string; name: string; color: number; text: string; ts: number }>>([]);
-  const [chatInput, setChatInput] = useState("");
   const [chatOpen, setChatOpen] = useState(false);
-  const chatInputRef = useRef<HTMLInputElement>(null);
   const sendChatRef = useRef<((text: string) => void) | null>(null);
 
   // ─── Show a multiplayer notification for 4 seconds ───────────────────────────
@@ -2847,7 +2846,6 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         e.preventDefault();
         document.exitPointerLock();
         setChatOpen(true);
-        setTimeout(() => chatInputRef.current?.focus(), 50);
       }
 
       // Digit keys 1–3 — select weapon in explore mode
@@ -6643,101 +6641,19 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
 
       {/* ─── Chat panel ───────────────────────────────────────────────────────── */}
       {gameStarted && (
-        <div
-          data-testid="chat-panel"
-          style={{
-            position: "fixed",
-            bottom: chatMessages.length > 0 || chatOpen ? 20 : -200,
-            left: "50%",
-            transform: "translateX(-50%)",
-            zIndex: 65,
-            width: 380,
-            maxWidth: "90vw",
-            transition: "bottom 0.3s ease",
-            pointerEvents: chatOpen ? "auto" : "none",
+        <ChatPanel
+          messages={chatMessages}
+          onSend={(text) => sendChatRef.current?.(text)}
+          isOpen={chatOpen}
+          onOpen={() => {
+            document.exitPointerLock();
+            setChatOpen(true);
           }}
-        >
-          {/* Chat message log */}
-          {chatMessages.length > 0 && (
-            <div
-              style={{
-                marginBottom: 6,
-                maxHeight: 150,
-                overflowY: "auto",
-                display: "flex",
-                flexDirection: "column",
-                gap: 3,
-              }}
-            >
-              {chatMessages.slice(-8).map((msg, i) => (
-                <div
-                  key={`${msg.ts}-${i}`}
-                  style={{
-                    padding: "4px 10px",
-                    borderRadius: 8,
-                    background: "rgba(5,8,20,0.78)",
-                    border: "1px solid rgba(255,255,255,0.07)",
-                    backdropFilter: "blur(8px)",
-                    fontSize: 12,
-                    color: "rgba(255,255,255,0.88)",
-                    display: "flex",
-                    gap: 6,
-                    alignItems: "baseline",
-                  }}
-                >
-                  <span
-                    style={{
-                      fontWeight: 700,
-                      color: `#${msg.color.toString(16).padStart(6, "0")}`,
-                      flexShrink: 0,
-                    }}
-                  >
-                    {msg.name}:
-                  </span>
-                  <span style={{ wordBreak: "break-word" }}>{msg.text}</span>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* Chat input (visible when chatOpen or game paused) */}
-          {chatOpen && (
-            <div style={{ display: "flex", gap: 6 }}>
-              <input
-                ref={chatInputRef}
-                type="text"
-                value={chatInput}
-                onChange={(e) => setChatInput(e.target.value.slice(0, 120))}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    const text = chatInput.trim();
-                    if (text) sendChatRef.current?.(text);
-                    setChatInput("");
-                    setChatOpen(false);
-                    lockPointer();
-                  }
-                  if (e.key === "Escape") {
-                    setChatInput("");
-                    setChatOpen(false);
-                    lockPointer();
-                  }
-                }}
-                placeholder="Zpráva… (Enter odešle, Esc zruší)"
-                maxLength={120}
-                style={{
-                  flex: 1,
-                  padding: "8px 12px",
-                  borderRadius: 10,
-                  background: "rgba(5,8,20,0.92)",
-                  border: "1px solid rgba(74,158,255,0.5)",
-                  color: "white",
-                  fontSize: 13,
-                  outline: "none",
-                }}
-              />
-            </div>
-          )}
-        </div>
+          onClose={() => {
+            setChatOpen(false);
+            lockPointer();
+          }}
+        />
       )}
 
       {/* ─── Sound mute button ─────────────────────────────────────────────── */}
@@ -6923,6 +6839,7 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
               new KeyboardEvent("keyup", { code: "KeyE", bubbles: true })
             );
           }}
+          onChatOpen={() => setChatOpen(true)}
           visible={true}
         />
       )}

--- a/liquid-glass-clock/components/MobileControls.tsx
+++ b/liquid-glass-clock/components/MobileControls.tsx
@@ -9,6 +9,7 @@ interface MobileControlsProps {
   onAttack: () => void;
   onInteract: () => void;
   visible: boolean;
+  onChatOpen?: () => void;
 }
 
 const JOYSTICK_RADIUS = 55; // visual radius of the joystick base (px)
@@ -21,6 +22,7 @@ export default function MobileControls({
   onAttack,
   onInteract,
   visible,
+  onChatOpen,
 }: MobileControlsProps) {
   const joystickKnobRef = useRef<HTMLDivElement | null>(null);
 
@@ -248,6 +250,16 @@ export default function MobileControls({
             keysRef.current["ShiftLeft"] = false;
           }}
         />
+
+        {/* Chat */}
+        {onChatOpen && (
+          <ActionButton
+            color="#a78bfa"
+            label="💬"
+            onPressStart={onChatOpen}
+            onPressEnd={() => {}}
+          />
+        )}
       </div>
 
       {/* ── Hint label for look zone ─────────────────────────────────────── */}

--- a/liquid-glass-clock/docs/chat-system.md
+++ b/liquid-glass-clock/docs/chat-system.md
@@ -1,0 +1,97 @@
+# Chat System
+
+Real-time in-game chat between players, built on top of the existing Socket.io multiplayer infrastructure.
+
+## Architecture
+
+```
+Browser (ChatPanel component)
+    ↕  Socket.io
+Server (server.mjs)  — in-memory broadcast
+    ↕  Socket.io
+All connected clients (ChatPanel component)
+```
+
+## Data Flow
+
+1. Player presses **T** (desktop) or taps **💬** (mobile) → `setChatOpen(true)` in `Game3D`
+2. `Game3D` renders `<ChatPanel isOpen={true} …>` → input is focused automatically
+3. Player types → presses **Enter** or clicks **Odeslat**
+4. `ChatPanel.onSend(text)` → `sendChatRef.current(text)` → `socket.emit("player:chat", { text })`
+5. Server validates & truncates to 120 chars, then broadcasts `chat:message` to **all** connected sockets
+6. `useMultiplayer` `onChatMessage` callback fires in each client
+7. `Game3D.handleChatMessage` appends message to `chatMessages` state (capped at 50)
+8. `ChatPanel` receives updated `messages` prop, syncs to its internal `TrackedMessage[]` list with `receivedAt` timestamp
+
+## Components
+
+### `components/ChatPanel.tsx`
+
+Self-contained floating overlay. Stateless with respect to messages (receives them via props).
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `messages` | `ChatMessage[]` | All chat messages (parent owns the array) |
+| `onSend` | `(text: string) => void` | Called when user submits a message |
+| `isOpen` | `boolean` | Controls input visibility & focus |
+| `onOpen` | `() => void` | Notification to parent to open chat |
+| `onClose` | `() => void` | Notification to parent to close & re-lock pointer |
+
+Features:
+- **Auto-fade** — messages start fading after 6 s and disappear at 7.5 s
+- **Auto-scroll** — log scrolls to the newest message when messages change
+- **Unread badge** — animated badge shows unread count when panel is closed and new messages arrive; clicking it calls `onOpen`
+- **Send button** — visible alternative to Enter key; disabled when input is empty
+- **Character limit** — enforces 120-character maximum, matching the server-side cap
+- **Keyboard shortcuts** — Enter sends, Escape cancels without sending
+
+### `hooks/useMultiplayer.ts`
+
+Already exposes `sendChat(text)` and `onChatMessage` callback. No changes required.
+
+### `server.mjs`
+
+Handles `player:chat` event, sanitises the message, and broadcasts `chat:message` to all sockets.
+
+```js
+socket.on("player:chat", ({ text }) => {
+  const msg = String(text).trim().slice(0, 120);
+  if (!msg) return;
+  io.emit("chat:message", { id, name, color, text: msg, ts: Date.now() });
+});
+```
+
+## Mobile Support
+
+`MobileControls` accepts an optional `onChatOpen?: () => void` prop. When provided, a **💬** button is rendered in the action-button column (bottom-right). Tapping it calls `onChatOpen`, which sets `chatOpen = true` in `Game3D`.
+
+## Keyboard Shortcut (Desktop)
+
+| Key | Action |
+|-----|--------|
+| `T` | Open chat (explore mode only; pointer lock is released) |
+| `Enter` | Send message & close input |
+| `Escape` | Cancel & close input |
+
+## Message Lifecycle
+
+```
+receivedAt + 0 ms     → opacity 1   (fully visible)
+receivedAt + 6000 ms  → begin fade
+receivedAt + 7500 ms  → opacity 0
+receivedAt + 7500 ms  → pruned from tracked list by cleanup interval (250 ms)
+```
+
+Max 50 messages are kept in memory; the panel renders at most the last 8.
+
+## Testing
+
+Tests are located in `__tests__/ChatPanel.test.tsx` and cover:
+- Rendering (container, empty state)
+- Message display (names, text, 8-message cap)
+- Input row visibility
+- Sending via Enter and button click
+- Whitespace-only message rejection
+- Character limit enforcement
+- Escape cancels without sending
+- Unread badge appearance and click behaviour


### PR DESCRIPTION
## Summary

The server-side chat was already complete, so the work focused on the client. A dedicated `ChatPanel` component was extracted from `Game3D.tsx` with auto-fading messages (visible 6 s, fade over 1.5 s), auto-scroll to the newest message, an animated unread-count badge, and a Send button alongside the Enter shortcut. Mobile players now have a 💬 button in `MobileControls` (via a new optional `onChatOpen` prop). All 26 new tests pass.

## Commits

- feat: implement player chat with auto-fade, unread badge, and mobile support