### PR TITLE
Udelej, aby trava byl jeste trikrat hustsi, ale stale aby to bylo optimalizovane a nesekalo se to kvuli tomu

### DIFF
--- a/liquid-glass-clock/__tests__/Game3D.test.tsx
+++ b/liquid-glass-clock/__tests__/Game3D.test.tsx
@@ -162,9 +162,10 @@ describe("Game3D component", () => {
     expect(() => render(<Game3D />)).not.toThrow();
   });
 
-  it("renders dense grass scene without crashing (GRASS_COUNT=60000)", () => {
-    // Ensures the grass (60 000 blades, 11–22 per cluster) still
+  it("renders dense grass scene without crashing (GRASS_COUNT=180000)", () => {
+    // Ensures the grass (180 000 blades, 11–22 per cluster, adaptive planes)
     // initialises without errors or memory overflows in the test environment.
+    // Test env uses 2000 blades to stay within memory limits.
     expect(() => render(<Game3D />)).not.toThrow();
   });
 

--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -1647,13 +1647,13 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     // ── Grass ───────────────────────────────────────────────────────────────
     {
       // Realistic grass: each blade uses a quadratic bezier curve baked into
-      // vertex positions, 3 planes with random Y-rotation (120° apart) for
-      // full volumetric appearance from all camera angles, true pointed tip,
-      // and 9 height bands for ultra-smooth curvature. Different cluster archetypes
-      // (short tuft / mixed meadow / tall reed) add habitat variety. A 4th plane
-      // is added to tall blades for a richer silhouette from all camera angles.
-      // Use a reduced count in test environments to keep memory within limits.
-      const GRASS_COUNT = process.env.NODE_ENV === "test" ? 2000 : 60000;
+      // vertex positions, 2-4 planes per blade (adaptive to height), true pointed
+      // tip, and 7 height bands for smooth curvature. Short blades (hScale < 0.80)
+      // use 2 planes to save GPU verts — 3× blade density compensates visually.
+      // Medium blades get 3 planes (120° apart), tall reeds get a 4th plane.
+      // Different cluster archetypes (short tuft / mixed meadow / tall reed) add
+      // habitat variety. Use a reduced count in test environments for memory limits.
+      const GRASS_COUNT = process.env.NODE_ENV === "test" ? 2000 : 180000;
       const BLADE_H_BASE = 0.76;   // slightly taller for lush appearance
       const BLADE_W_BASE = 0.086;  // narrower base for more realistic slender blades
       let gSeed = 7391;
@@ -1679,12 +1679,11 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
       const CLUSTER_RADIUS = 0.65;  // tighter clusters for denser appearance
       const BLADES_MIN = 11;        // at least 11 blades per cluster
       const BLADES_MAX = 22;        // up to 22 for very dense tufts
-      // Height band t-values: 9 bands give 8 regular quads + 1 tip triangle per plane.
-      // Dense at base (short segments) for accurate root curvature, spaced wider
-      // toward tip where the bezier curve is more linear — maximises smoothness
-      // at the most visually prominent part (the bend). Extra bands add detail to
-      // the mid-blade curve which is where the natural drape is most visible.
-      const H_LEVELS = [0, 0.04, 0.11, 0.20, 0.31, 0.44, 0.58, 0.72, 0.85, 0.94, 1.0];
+      // Height band t-values: 7 bands give 6 regular quads + 1 tip triangle per plane.
+      // Reduced from 11 to 8 entries (7 segments) to cut per-blade vertex count by ~30%
+      // while tripling blade count — density compensates for slightly simpler curves.
+      // Still denser at base for accurate root curvature where the bend is most visible.
+      const H_LEVELS = [0, 0.06, 0.18, 0.34, 0.52, 0.72, 0.88, 1.0];
       let placed = 0;
       let tries = 0;
 
@@ -1895,17 +1894,25 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
             }
           };
 
-          // Three planes spaced ~120° apart with slight asymmetric jitter —
-          // breaks the too-perfect star look and feels more organic.
+          // Plane count adapts to blade height — short blades (hScale < 0.80) get
+          // 2 planes at 90° apart: density from 3× more blades compensates for
+          // one fewer cross-section. Medium blades keep 3 planes (120° apart).
           // Tall blades (hScale > 1.25) get a 4th plane at ~90° offset so the
           // silhouette looks full from all camera angles, not just head-on.
           const planeJitter = (gRng() - 0.5) * 0.28;
           pushPlane(rotY);
-          pushPlane(rotY + Math.PI / 3 * 2 + planeJitter);
-          pushPlane(rotY + Math.PI / 3 * 4 - planeJitter * 0.5);
-          // 4th plane only for tall reeds/long grass — adds volumetric depth
-          if (hScale > 1.25) {
-            pushPlane(rotY + Math.PI / 2 + planeJitter * 0.3);
+          if (hScale < 0.80) {
+            // 2 planes at 90° — saves ~33% vertices for short grass which is
+            // visually compensated by the 3× blade density increase.
+            pushPlane(rotY + Math.PI / 2 + planeJitter);
+          } else {
+            // 3 planes for medium/tall grass — full volumetric appearance
+            pushPlane(rotY + Math.PI / 3 * 2 + planeJitter);
+            pushPlane(rotY + Math.PI / 3 * 4 - planeJitter * 0.5);
+            // 4th plane only for tall reeds/long grass — adds volumetric depth
+            if (hScale > 1.25) {
+              pushPlane(rotY + Math.PI / 2 + planeJitter * 0.3);
+            }
           }
 
           placed++;


### PR DESCRIPTION
## Summary

Tráva je nyní 3x hustší (180 000 stébel místo 60 000) a zároveň zůstává výkon optimalizovaný dvěma způsoby: počet výškových pásem na každém stéblu byl snížen z 11 na 8 (30 % méně vrcholů/stéblo), a krátká tráva (hScale < 0.80) dostává 2 roviny místo 3 — hustota sousedních stébel vizuálně kompenzuje jednu chybějící rovinu. Výsledný celkový počet vrcholů na GPU je přibližně 1.7× aktuální stav, tedy daleko pod trojnásobkem, který by vznikl bez optimalizace.

## Commits

- perf: triple grass density (60k → 180k blades) with adaptive LOD geometry