### PR TITLE
Pridej texturu terenu

### DIFF
--- a/liquid-glass-clock/__tests__/terrainTextures.test.ts
+++ b/liquid-glass-clock/__tests__/terrainTextures.test.ts
@@ -1,0 +1,155 @@
+import {
+  generateTerrainTextureData,
+  TerrainTextureType,
+} from "@/lib/terrainTextures";
+
+const ALL_TYPES: TerrainTextureType[] = ["grass", "rock", "sand", "snow", "dirt"];
+
+describe("generateTerrainTextureData", () => {
+  const SIZE = 64; // small size for fast tests
+
+  describe("output format", () => {
+    it("returns a Uint8ClampedArray", () => {
+      const data = generateTerrainTextureData("grass", SIZE);
+      expect(data).toBeInstanceOf(Uint8ClampedArray);
+    });
+
+    it.each(ALL_TYPES)("returns size*size*4 bytes for %s", (type) => {
+      const data = generateTerrainTextureData(type, SIZE);
+      expect(data.length).toBe(SIZE * SIZE * 4);
+    });
+
+    it.each(ALL_TYPES)("all alpha values are 255 for %s", (type) => {
+      const data = generateTerrainTextureData(type, SIZE);
+      for (let i = 3; i < data.length; i += 4) {
+        expect(data[i]).toBe(255);
+      }
+    });
+  });
+
+  describe("pixel value ranges", () => {
+    it.each(ALL_TYPES)("all RGB channels are in [0, 255] for %s", (type) => {
+      const data = generateTerrainTextureData(type, SIZE);
+      for (let i = 0; i < data.length; i += 4) {
+        expect(data[i + 0]).toBeGreaterThanOrEqual(0);
+        expect(data[i + 0]).toBeLessThanOrEqual(255);
+        expect(data[i + 1]).toBeGreaterThanOrEqual(0);
+        expect(data[i + 1]).toBeLessThanOrEqual(255);
+        expect(data[i + 2]).toBeGreaterThanOrEqual(0);
+        expect(data[i + 2]).toBeLessThanOrEqual(255);
+      }
+    });
+  });
+
+  describe("biome colour characteristics", () => {
+    const avgChannel = (
+      data: Uint8ClampedArray,
+      channel: 0 | 1 | 2
+    ): number => {
+      let sum = 0;
+      for (let i = channel; i < data.length; i += 4) sum += data[i];
+      return sum / (data.length / 4);
+    };
+
+    it("grass texture is dominantly green (G > R, G > B)", () => {
+      const data = generateTerrainTextureData("grass", SIZE);
+      const r = avgChannel(data, 0);
+      const g = avgChannel(data, 1);
+      const b = avgChannel(data, 2);
+      expect(g).toBeGreaterThan(r);
+      expect(g).toBeGreaterThan(b);
+    });
+
+    it("sand texture is warm (R > B, G > B)", () => {
+      const data = generateTerrainTextureData("sand", SIZE);
+      const r = avgChannel(data, 0);
+      const g = avgChannel(data, 1);
+      const b = avgChannel(data, 2);
+      expect(r).toBeGreaterThan(b);
+      expect(g).toBeGreaterThan(b);
+    });
+
+    it("snow texture is bright (avg luminance > 180)", () => {
+      const data = generateTerrainTextureData("snow", SIZE);
+      const r = avgChannel(data, 0);
+      const g = avgChannel(data, 1);
+      const b = avgChannel(data, 2);
+      const lum = 0.299 * r + 0.587 * g + 0.114 * b;
+      expect(lum).toBeGreaterThan(180);
+    });
+
+    it("dirt texture is darker than snow (lower average luminance)", () => {
+      const dirtData = generateTerrainTextureData("dirt", SIZE);
+      const snowData = generateTerrainTextureData("snow", SIZE);
+      const dirtLum =
+        0.299 * avgChannel(dirtData, 0) +
+        0.587 * avgChannel(dirtData, 1) +
+        0.114 * avgChannel(dirtData, 2);
+      const snowLum =
+        0.299 * avgChannel(snowData, 0) +
+        0.587 * avgChannel(snowData, 1) +
+        0.114 * avgChannel(snowData, 2);
+      expect(dirtLum).toBeLessThan(snowLum);
+    });
+
+    it("rock texture has visible variation (std dev > 5 on R channel)", () => {
+      const data = generateTerrainTextureData("rock", SIZE);
+      const values: number[] = [];
+      for (let i = 0; i < data.length; i += 4) values.push(data[i]);
+      const mean = values.reduce((a, b) => a + b, 0) / values.length;
+      const variance =
+        values.reduce((s, v) => s + (v - mean) ** 2, 0) / values.length;
+      expect(Math.sqrt(variance)).toBeGreaterThan(5);
+    });
+  });
+
+  describe("determinism", () => {
+    it.each(ALL_TYPES)(
+      "produces identical output on repeated calls for %s",
+      (type) => {
+        const a = generateTerrainTextureData(type, SIZE);
+        const b = generateTerrainTextureData(type, SIZE);
+        expect(a).toEqual(b);
+      }
+    );
+  });
+
+  describe("texture size variants", () => {
+    it("works correctly with size 32", () => {
+      const data = generateTerrainTextureData("grass", 32);
+      expect(data.length).toBe(32 * 32 * 4);
+    });
+
+    it("works correctly with size 128", () => {
+      const data = generateTerrainTextureData("rock", 128);
+      expect(data.length).toBe(128 * 128 * 4);
+    });
+
+    it("produces different output for size 32 vs size 64", () => {
+      const small = generateTerrainTextureData("grass", 32);
+      const large = generateTerrainTextureData("grass", 64);
+      // They have different lengths so they can't be equal
+      expect(small.length).not.toBe(large.length);
+    });
+  });
+
+  describe("type isolation", () => {
+    it("grass and rock textures have different pixel data at the same size", () => {
+      const grass = generateTerrainTextureData("grass", SIZE);
+      const rock = generateTerrainTextureData("rock", SIZE);
+      let different = false;
+      for (let i = 0; i < grass.length; i++) {
+        if (grass[i] !== rock[i]) { different = true; break; }
+      }
+      expect(different).toBe(true);
+    });
+
+    it("all five biome types produce distinct pixel data", () => {
+      const results = ALL_TYPES.map((t) =>
+        Array.from(generateTerrainTextureData(t, SIZE).slice(0, 64))
+      );
+      const uniqueKeys = new Set(results.map((r) => JSON.stringify(r)));
+      expect(uniqueKeys.size).toBe(ALL_TYPES.length);
+    });
+  });
+});

--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -16,6 +16,7 @@ import {
   TERRAIN_SEGMENTS,
   WATER_LEVEL,
 } from "@/lib/terrainUtils";
+import { createTerrainTexture } from "@/lib/terrainTextures";
 import {
   BlockMaterial,
   BuildMode,
@@ -1299,6 +1300,15 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     scene.add(galaxy);
     galaxyRef.current = galaxy;
 
+    // ── Terrain textures (see lib/terrainTextures.ts) ────────────────────────
+    // Procedural canvas textures for each biome; sampled via triplanar mapping
+    // in the fragment shader to add surface micro-detail without external assets.
+    const terrainTexGrass = createTerrainTexture("grass");
+    const terrainTexRock  = createTerrainTexture("rock");
+    const terrainTexSand  = createTerrainTexture("sand");
+    const terrainTexSnow  = createTerrainTexture("snow");
+    const terrainTexDirt  = createTerrainTexture("dirt");
+
     // ── Terrain ─────────────────────────────────────────────────────────────
     const terrainGeo = new THREE.PlaneGeometry(
       WORLD_SIZE,
@@ -1322,6 +1332,16 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         uSunColor:     { value: new THREE.Color(1.0, 0.95, 0.80) },
         uSunIntensity: { value: 1.0 },
         uAmbientColor: { value: new THREE.Color(0.30, 0.38, 0.52) },
+        // Biome detail textures
+        uTexGrass:     { value: terrainTexGrass },
+        uTexRock:      { value: terrainTexRock  },
+        uTexSand:      { value: terrainTexSand  },
+        uTexSnow:      { value: terrainTexSnow  },
+        uTexDirt:      { value: terrainTexDirt  },
+        // Texture tiling scale (world units per tile repeat)
+        uTexScale:     { value: 1.0 / 8.0 },
+        // Texture blend strength (0 = no texture, 1 = full texture)
+        uTexStrength:  { value: 0.40 },
       },
       vertexShader: /* glsl */`
         varying vec3 vWorldPos;
@@ -1340,6 +1360,15 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         uniform vec3  uSunColor;
         uniform float uSunIntensity;
         uniform vec3  uAmbientColor;
+
+        // Biome textures
+        uniform sampler2D uTexGrass;
+        uniform sampler2D uTexRock;
+        uniform sampler2D uTexSand;
+        uniform sampler2D uTexSnow;
+        uniform sampler2D uTexDirt;
+        uniform float     uTexScale;
+        uniform float     uTexStrength;
 
         varying vec3  vWorldPos;
         varying vec3  vNormal;
@@ -1368,6 +1397,22 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
             a *= 0.5;
           }
           return v;
+        }
+
+        // ── Triplanar texture sampling ────────────────────────────────────────────
+        // Blends top-projection with side-projections on steep slopes for
+        // seamless texturing regardless of surface orientation.
+        vec3 triplanar(sampler2D tex, vec3 worldPos, vec3 normal, float scale) {
+          vec2 uvXZ = worldPos.xz * scale;
+          vec2 uvXY = worldPos.xy * scale;
+          vec2 uvZY = worldPos.zy * scale;
+          vec3 blendW = abs(normal);
+          blendW = pow(blendW, vec3(4.0));
+          blendW /= (blendW.x + blendW.y + blendW.z + 0.0001);
+          vec3 tXZ = texture2D(tex, uvXZ).rgb;
+          vec3 tXY = texture2D(tex, uvXY).rgb;
+          vec3 tZY = texture2D(tex, uvZY).rgb;
+          return tXZ * blendW.y + tXY * blendW.z + tZY * blendW.x;
         }
 
         // ── Biome palette ─────────────────────────────────────────────────────────
@@ -1399,40 +1444,60 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
 
           // ── Biome color ────────────────────────────────────────────────────────
           vec3 col;
+
+          // Biome texture weights (sum used for triplanar blending)
+          float wGrass = 0.0;
+          float wRock  = 0.0;
+          float wSand  = 0.0;
+          float wSnow  = 0.0;
+          float wDirt  = 0.0;
+
           if (hWobble < -3.0) {
             col = cDeepWater;
+            // Water: no texture blend (handled by water plane above)
           } else if (hWobble < -0.5) {
             float t = clamp((hWobble + 3.0) / 2.5, 0.0, 1.0);
             col = mix(cDeepWater, cShallowWater, t);
+            wSand = t * 0.4;
           } else if (hWobble < 0.4) {
             float t = clamp((hWobble + 0.5) / 0.9, 0.0, 1.0);
             // Sand variation: lighter/darker patches
             vec3 sandVar = mix(cSandDark, cSand, vnoise(uv * 1.8));
             col = mix(cShallowWater, sandVar, t);
+            wSand = t;
           } else if (hWobble < 2.5) {
             float t = clamp((hWobble - 0.4) / 2.1, 0.0, 1.0);
             // Patchy transition from sand to grass (dry tufts)
             vec3 grassVar = mix(cBrightGrass, cDryGrass, meso * 0.5);
             col = mix(cSand, grassVar, t);
+            wSand  = 1.0 - t;
+            wGrass = t;
           } else if (hWobble < 7.0) {
             float t = clamp((hWobble - 2.5) / 4.5, 0.0, 1.0);
             // Bright → mid grass: patchy colour variation from noise
             vec3 g1 = mix(cBrightGrass, cDryGrass,   macro * 0.35);
             vec3 g2 = mix(cMidGrass,    cBrightGrass, meso  * 0.40);
             col = mix(g1, g2, t + (micro - 0.5) * 0.25);
+            wGrass = 1.0;
           } else if (hWobble < 17.0) {
             float t = clamp((hWobble - 7.0) / 10.0, 0.0, 1.0);
             vec3 g1 = mix(cMidGrass,  cBrightGrass, micro * 0.25);
             vec3 g2 = mix(cDarkGrass, cMidGrass,    meso  * 0.30);
             col = mix(g1, g2, t + (macro - 0.5) * 0.20);
+            wGrass = 1.0 - t * 0.5;
+            wDirt  = t * 0.5;
           } else if (hWobble < 28.0) {
             float t = clamp((hWobble - 17.0) / 11.0, 0.0, 1.0);
             vec3 rockVar = mix(cRockBrown, cRockGray, vnoise(uv * 1.2));
             col = mix(cDarkGrass, rockVar, t);
+            wDirt = 1.0 - t;
+            wRock = t;
           } else {
             float t = clamp((hWobble - 28.0) / 12.0, 0.0, 1.0);
             vec3 rockVar = mix(cRockBrown, cRockLight, vnoise(uv * 1.5));
             col = mix(rockVar, cSnow, t);
+            wRock = 1.0 - t;
+            wSnow = t;
           }
 
           // ── Slope → cliff rock overlay ────────────────────────────────────────
@@ -1443,6 +1508,48 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
             vec3  cliffCol    = mix(cRockBrown, cRockGray, vnoise(uv * 0.9 + vec2(7.3, 2.1)));
             cliffCol *= mix(0.72, 1.05, crackDetail); // darker cracks, lighter faces
             col = mix(col, cliffCol, rockBlend);
+            // Shift texture weights towards rock on steep slopes
+            float rShift = rockBlend;
+            wGrass *= (1.0 - rShift);
+            wSand  *= (1.0 - rShift);
+            wDirt  *= (1.0 - rShift * 0.5);
+            wSnow  *= (1.0 - rShift * 0.7);
+            wRock  = clamp(wRock + rShift, 0.0, 1.0);
+          }
+
+          // ── Texture detail sampling (triplanar projection) ────────────────────
+          // Biome textures provide surface micro-detail to break up flat-colour look.
+          // Each texture is sampled at two scales and blended.
+          float totalW = wGrass + wRock + wSand + wSnow + wDirt + 0.0001;
+          vec3 texDetail = vec3(0.5); // neutral grey (no detail)
+
+          if (uTexStrength > 0.001) {
+            vec3 tGrass = triplanar(uTexGrass, vWorldPos, vNormal, uTexScale);
+            vec3 tRock  = triplanar(uTexRock,  vWorldPos, vNormal, uTexScale * 0.6);
+            vec3 tSand  = triplanar(uTexSand,  vWorldPos, vNormal, uTexScale * 1.2);
+            vec3 tSnow  = triplanar(uTexSnow,  vWorldPos, vNormal, uTexScale * 0.8);
+            vec3 tDirt  = triplanar(uTexDirt,  vWorldPos, vNormal, uTexScale * 0.9);
+
+            texDetail = (tGrass * wGrass + tRock * wRock + tSand * wSand
+                         + tSnow * wSnow + tDirt * wDirt) / totalW;
+
+            // Apply second (coarser) scale for depth
+            vec3 tGrass2 = triplanar(uTexGrass, vWorldPos, vNormal, uTexScale * 0.25);
+            vec3 tRock2  = triplanar(uTexRock,  vWorldPos, vNormal, uTexScale * 0.20);
+            vec3 tSand2  = triplanar(uTexSand,  vWorldPos, vNormal, uTexScale * 0.30);
+            vec3 tSnow2  = triplanar(uTexSnow,  vWorldPos, vNormal, uTexScale * 0.22);
+            vec3 tDirt2  = triplanar(uTexDirt,  vWorldPos, vNormal, uTexScale * 0.24);
+
+            vec3 texCoarse = (tGrass2 * wGrass + tRock2 * wRock + tSand2 * wSand
+                              + tSnow2 * wSnow + tDirt2 * wDirt) / totalW;
+
+            // Combine fine and coarse detail
+            texDetail = texDetail * 0.65 + texCoarse * 0.35;
+
+            // Remap: centre at 0.5 so blend is multiplicative-neutral
+            // col * (1 + strength*(detail - 0.5)*2) keeps average brightness
+            float detailFactor = 1.0 + uTexStrength * (texDetail.r * 0.4 + texDetail.g * 0.4 + texDetail.b * 0.2 - 0.5) * 2.0;
+            col *= clamp(detailFactor, 0.55, 1.55);
           }
 
           // ── Micro-shading: subtle brightness variation ─────────────────────────
@@ -5660,6 +5767,12 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
       if (rainRef.current) { scene.remove(rainRef.current); rainRef.current = null; }
       if (lightningBoltRef.current) { scene.remove(lightningBoltRef.current); lightningBoltRef.current = null; }
       soundManager.destroy();
+      // Dispose procedural terrain textures
+      terrainTexGrass.dispose();
+      terrainTexRock.dispose();
+      terrainTexSand.dispose();
+      terrainTexSnow.dispose();
+      terrainTexDirt.dispose();
       renderer.dispose();
       if (mountNode) {
         mountNode.removeChild(renderer.domElement);

--- a/liquid-glass-clock/docs/terrain-system.md
+++ b/liquid-glass-clock/docs/terrain-system.md
@@ -1,0 +1,120 @@
+# Terrain System
+
+## Overview
+
+The terrain is a procedurally generated 267×267-unit heightmap rendered with a custom GLSL `ShaderMaterial`. It combines large-scale biome colour zoning, multi-scale noise variation, and (as of March 2026) per-biome surface textures applied via **triplanar projection**.
+
+---
+
+## Architecture
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `lib/terrainUtils.ts` | Height generation (noise, biome sampling, height grid) |
+| `lib/terrainTextures.ts` | Procedural canvas texture generation for biomes |
+| `components/Game3D.tsx` | Three.js scene setup: terrain mesh, `ShaderMaterial`, grass, water |
+| `__tests__/terrainTextures.test.ts` | Unit tests for texture generator |
+
+### Constants (`terrainUtils.ts`)
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `WORLD_SIZE` | 267 | Side length of the terrain in world units |
+| `TERRAIN_SEGMENTS` | 120 | Vertex resolution per axis of the PlaneGeometry |
+| `WATER_LEVEL` | -0.5 | Y threshold below which terrain is considered water |
+
+---
+
+## Terrain Mesh
+
+A `THREE.PlaneGeometry(WORLD_SIZE, WORLD_SIZE, TERRAIN_SEGMENTS, TERRAIN_SEGMENTS)` is created, rotated −90° on X, then each vertex Y position is set by `getTerrainHeight(x, z)`.  Vertex normals are recomputed after deformation.
+
+---
+
+## Terrain Shader
+
+The terrain uses `THREE.ShaderMaterial` with a fully custom vertex + fragment shader, so no MeshStandard/Phong lighting model is used.
+
+### Uniforms
+
+| Uniform | Type | Purpose |
+|---------|------|---------|
+| `uSunDir` | `vec3` | Normalised sun direction |
+| `uSunColor` | `vec3` | Sun tint (warm yellow-white) |
+| `uSunIntensity` | `float` | 0–1 intensity multiplier |
+| `uAmbientColor` | `vec3` | Sky ambient fill colour |
+| `uTexGrass` | `sampler2D` | Procedural grass surface texture |
+| `uTexRock` | `sampler2D` | Procedural rock/stone surface texture |
+| `uTexSand` | `sampler2D` | Procedural sand surface texture |
+| `uTexSnow` | `sampler2D` | Procedural snow surface texture |
+| `uTexDirt` | `sampler2D` | Procedural dirt/soil surface texture |
+| `uTexScale` | `float` | Tiling frequency (default `1/8` → 8-unit tile) |
+| `uTexStrength` | `float` | Texture blend strength 0–1 (default 0.40) |
+
+### Fragment Shader Stages
+
+1. **Multi-scale FBM noise** – `macro` (~40 u), `meso` (~10 u), `micro` (~2 u), `crack` patterns.
+2. **Biome classification** – height-wobbled by macro/meso noise to produce organic borders.  Biomes: deep water → shallow water → sand → dry grass → bright grass → mid/dark grass → rock → snow.
+3. **Slope rock overlay** – `smoothstep(0.38, 0.65, slope)` on the dot(normal, up) to push cliffs towards rock colour.
+4. **Triplanar texture sampling** – each biome texture is sampled in three planes (XZ, XY, ZY) and blended by the surface normal to avoid stretching on vertical cliffs.  Weights for each biome are tracked during the biome pass and normalised before sampling.  A coarse second sample (4× lower frequency) is mixed in at 35 % for depth.
+5. **Texture detail factor** – `col *= 1 + strength*(luminance(detail) - 0.5)*2`.  This is a multiplicative approach that preserves the average biome brightness while adding ±contrast.
+6. **Micro-shading** – `col *= 0.90 + micro * 0.18` for subtle per-pixel brightness jitter.
+7. **Lambert lighting** – `col * (ambient + sun * diffuse * intensity)`.
+
+---
+
+## Procedural Textures (`lib/terrainTextures.ts`)
+
+### `generateTerrainTextureData(type, size)`
+
+Pure function (no DOM dependency) that returns a `Uint8ClampedArray` of `size×size×4` RGBA pixels.
+
+**Algorithm**:
+1. Seeded LCG RNG initialised per biome type → deterministic, no external randomness.
+2. 2D value noise grid (bilinear-interpolated) sampled at 8 frequency bands.
+3. Fractal Brownian Motion (4 octaves) stacked at three spatial frequencies.
+4. Per-biome pixel formula:
+
+| Biome | Key visual feature |
+|-------|--------------------|
+| `grass` | Bright green, blade-like high-freq detail |
+| `rock` | Gray-brown with crack-dark lines |
+| `sand` | Warm beige with sin-wave ripple |
+| `snow` | Bright white, blue crystal sparkle |
+| `dirt` | Dark loamy brown, earthy grain |
+
+### `createTerrainTexture(type, size)` (browser only)
+
+Wraps the above in a `THREE.CanvasTexture` with `RepeatWrapping` and mipmap generation.
+
+---
+
+## Grass Layer
+
+Grass is a separate `THREE.Points` geometry with per-blade procedural colour (5 archetypes: straw, rust, olive, bright green, lush dark green, blue-green).  It has its own `ShaderMaterial` with wind animation, subsurface scattering, and camera-based LOD fade.  Not part of the terrain shader.
+
+---
+
+## Runtime Updates
+
+Each animation frame updates terrain shader uniforms to match the day/night cycle:
+
+```ts
+terrainMatRef.current.uniforms.uSunDir.value.copy(sunPos).normalize();
+terrainMatRef.current.uniforms.uSunIntensity.value = getSunIntensity(dayFraction);
+// ambient colour shifts between day-blue and night-purple
+```
+
+---
+
+## Testing
+
+`__tests__/terrainTextures.test.ts` covers:
+- Output format (type, length, alpha)
+- All channels in [0, 255]
+- Biome colour characteristics (green dominant for grass, bright for snow, etc.)
+- Determinism (same seed → same pixels)
+- Multiple texture sizes
+- All five biome types produce distinct data

--- a/liquid-glass-clock/lib/terrainTextures.ts
+++ b/liquid-glass-clock/lib/terrainTextures.ts
@@ -1,0 +1,176 @@
+/**
+ * Procedural terrain texture generation utilities.
+ *
+ * Each biome type gets a tileable 2D texture generated entirely in JS/Canvas,
+ * so no external image assets are required.  The textures are sampled in the
+ * terrain GLSL shader via triplanar projection to add high-frequency surface
+ * detail on top of the procedural biome colour palette.
+ *
+ * Architecture note:
+ *   generateTerrainTextureData() – pure function, no DOM dependency (testable)
+ *   createTerrainTexture()       – thin wrapper that converts the result to a
+ *                                   THREE.CanvasTexture (browser-only)
+ */
+
+export type TerrainTextureType = "grass" | "rock" | "sand" | "snow" | "dirt";
+
+/**
+ * Returns the RGBA pixel data for a tileable procedural terrain texture.
+ *
+ * @param type  Biome type
+ * @param size  Canvas side length in pixels (must be power of 2, default 256)
+ * @returns     Uint8ClampedArray of length size*size*4 (RGBA)
+ */
+export function generateTerrainTextureData(
+  type: TerrainTextureType,
+  size = 256
+): Uint8ClampedArray {
+  // ── Seedable LCG RNG for deterministic, repeatable output ──────────────────
+  const typeSeeds: Record<TerrainTextureType, number> = {
+    grass: 42,
+    rock: 137,
+    sand: 251,
+    snow: 89,
+    dirt: 314,
+  };
+  let seed = typeSeeds[type];
+  const rand = (): number => {
+    seed = (seed * 1664525 + 1013904223) & 0xffffffff;
+    return (seed >>> 0) / 0xffffffff;
+  };
+
+  // ── Build a value-noise grid (bilinear-interpolated) ──────────────────────
+  const noiseGrid = new Float32Array(size * size);
+  for (let i = 0; i < noiseGrid.length; i++) noiseGrid[i] = rand();
+
+  const bilinear = (x: number, y: number): number => {
+    const ix = Math.floor(x) & (size - 1);
+    const iy = Math.floor(y) & (size - 1);
+    const fx = x - Math.floor(x);
+    const fy = y - Math.floor(y);
+    const ix1 = (ix + 1) & (size - 1);
+    const iy1 = (iy + 1) & (size - 1);
+    const a = noiseGrid[iy * size + ix];
+    const b = noiseGrid[iy * size + ix1];
+    const c = noiseGrid[iy1 * size + ix];
+    const d = noiseGrid[iy1 * size + ix1];
+    const ux = fx * fx * (3 - 2 * fx);
+    const uy = fy * fy * (3 - 2 * fy);
+    return a + (b - a) * ux + (c - a) * uy + (a - b - c + d) * ux * uy;
+  };
+
+  /** Fractal Brownian Motion – stacks octaves of bilinear noise */
+  const fbm = (x: number, y: number, octaves = 4): number => {
+    let v = 0;
+    let amp = 0.5;
+    let freq = 1.0;
+    let max = 0;
+    for (let o = 0; o < octaves; o++) {
+      v += bilinear(x * freq, y * freq) * amp;
+      max += amp;
+      amp *= 0.5;
+      freq *= 2.1;
+    }
+    return v / max;
+  };
+
+  // ── Write pixel data ───────────────────────────────────────────────────────
+  const data = new Uint8ClampedArray(size * size * 4);
+
+  for (let py = 0; py < size; py++) {
+    for (let px = 0; px < size; px++) {
+      const idx = (py * size + px) * 4;
+      const nx = (px / size) * 8;
+      const ny = (py / size) * 8;
+
+      const n0 = fbm(nx, ny, 4);
+      const n1 = fbm(nx * 2.3 + 5.1, ny * 2.3 + 3.7, 3);
+      const n2 = fbm(nx * 6.0 + 1.2, ny * 6.0 + 8.4, 2);
+
+      let r = 0;
+      let g = 0;
+      let b = 0;
+
+      if (type === "grass") {
+        // Green tones with blade-like high-frequency detail
+        const blade = n2 * 0.4 + n1 * 0.35 + n0 * 0.25;
+        const bright = 0.6 + blade * 0.38;
+        r = (0.18 + n0 * 0.12) * bright;
+        g = (0.52 + n1 * 0.18) * bright;
+        b = (0.08 + n0 * 0.06) * bright;
+      } else if (type === "rock") {
+        // Gray-brown stony texture with crack-like dark lines
+        const grain = n0 * 0.5 + n1 * 0.3 + n2 * 0.2;
+        const crack = Math.pow(Math.abs(n1 - 0.5) * 2.0, 2.2);
+        const val = 0.45 + grain * 0.35 - crack * 0.25;
+        r = val + 0.05;
+        g = val * 0.93;
+        b = val * 0.82;
+      } else if (type === "sand") {
+        // Warm beige with ripple-like directional patterns
+        const ripple = Math.sin((px + n0 * 12) * 0.4) * 0.5 + 0.5;
+        const grain = n1 * 0.4 + n2 * 0.3 + ripple * 0.3;
+        const val = 0.65 + grain * 0.28;
+        r = Math.min(1, val + 0.12);
+        g = Math.min(1, val + 0.02);
+        b = Math.min(1, val - 0.18);
+      } else if (type === "snow") {
+        // Bright white with faint blue crystal glint
+        const sparkle = Math.pow(n2, 3.0);
+        const val = 0.82 + n0 * 0.12 + sparkle * 0.06;
+        r = Math.min(1, val);
+        g = Math.min(1, val + 0.01);
+        b = Math.min(1, val + 0.06 + sparkle * 0.08);
+      } else {
+        // dirt: dark earth, loamy brown
+        const grain = n0 * 0.45 + n1 * 0.35 + n2 * 0.2;
+        const val = 0.28 + grain * 0.3;
+        r = Math.min(1, val + 0.1);
+        g = Math.min(1, val * 0.8);
+        b = Math.min(1, val * 0.55);
+      }
+
+      data[idx + 0] = Math.max(0, Math.min(255, Math.round(r * 255)));
+      data[idx + 1] = Math.max(0, Math.min(255, Math.round(g * 255)));
+      data[idx + 2] = Math.max(0, Math.min(255, Math.round(b * 255)));
+      data[idx + 3] = 255;
+    }
+  }
+
+  return data;
+}
+
+/**
+ * Creates a browser-side THREE.CanvasTexture for a terrain biome.
+ * Must only be called in a browser environment (document must exist).
+ *
+ * @param type  Biome type
+ * @param size  Texture resolution (power of 2, default 256)
+ */
+export function createTerrainTexture(
+  type: TerrainTextureType,
+  size = 256
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any /* THREE.CanvasTexture – avoid hard THREE import at util level */ {
+  // Inline require keeps THREE out of server-side bundles
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const THREE = require("three");
+
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d")!;
+
+  const pixels = generateTerrainTextureData(type, size);
+  const img = ctx.createImageData(size, size);
+  img.data.set(pixels);
+  ctx.putImageData(img, 0, 0);
+
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  tex.minFilter = THREE.LinearMipMapLinearFilter;
+  tex.magFilter = THREE.LinearFilter;
+  tex.generateMipmaps = true;
+  return tex;
+}


### PR DESCRIPTION
## Summary

Terrain textures have been successfully added. Five procedural canvas textures (grass, rock, sand, snow, dirt) are generated at startup using a seeded LCG + FBM value noise algorithm — no external image assets required. The terrain fragment shader was extended with a triplanar projection helper and per-biome texture weight tracking, so textures blend correctly across all surface orientations including steep cliff faces. All 31 tests pass and TypeScript compiles cleanly.

## Commits

- feat: add procedural terrain textures with triplanar mapping