### PR TITLE
Stale nefunguje nastupovani do vesmirne lodi... TEd raketou vyleti nahoru... ale pak me to z rakety vykopne a objevim se

### DIFF
--- a/liquid-glass-clock/__tests__/spaceStation.test.ts
+++ b/liquid-glass-clock/__tests__/spaceStation.test.ts
@@ -240,3 +240,49 @@ describe("Auto-docking: rocket arrives → immediate space station entry", () =>
     expect(SPACE_STATION_WORLD_Y).toBe(2000);
   });
 });
+
+// ── Rocket E-key exit guard: only exit in idle/boarded state ─────────────────
+describe("Rocket E-key exit guard", () => {
+  /**
+   * Mirrors the logic in Game3D.tsx: pressing E while on rocket should
+   * only detach the player when the rocket is in 'idle' or 'boarded' state.
+   * During 'launching', 'countdown', 'arrived', and 'docked' the E key must
+   * be a no-op on this branch (arrived is handled by the station-entry block).
+   */
+  type RocketStateType = "idle" | "boarded" | "countdown" | "launching" | "arrived" | "docked";
+
+  function canExitRocket(state: RocketStateType): boolean {
+    return state === "idle" || state === "boarded";
+  }
+
+  it("allows exit while idle", () => {
+    expect(canExitRocket("idle")).toBe(true);
+  });
+
+  it("allows exit while boarded (pre-launch)", () => {
+    expect(canExitRocket("boarded")).toBe(true);
+  });
+
+  it("does NOT allow exit while in countdown", () => {
+    expect(canExitRocket("countdown")).toBe(false);
+  });
+
+  it("does NOT allow exit while launching — prevents mid-flight ejection", () => {
+    expect(canExitRocket("launching")).toBe(false);
+  });
+
+  it("does NOT allow exit while arrived — station-entry branch handles this", () => {
+    expect(canExitRocket("arrived")).toBe(false);
+  });
+
+  it("does NOT allow exit while docked", () => {
+    expect(canExitRocket("docked")).toBe(false);
+  });
+
+  it("exactly two states allow rocket exit", () => {
+    const allStates: RocketStateType[] = ["idle", "boarded", "countdown", "launching", "arrived", "docked"];
+    const exitableStates = allStates.filter(canExitRocket);
+    expect(exitableStates).toHaveLength(2);
+    expect(exitableStates).toEqual(["idle", "boarded"]);
+  });
+});

--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -2926,7 +2926,7 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         }
 
         if (onRocketRef.current) {
-          // ── Exit rocket (only allowed while idle/boarded, not during launch) ─
+          // ── Exit rocket (only allowed while idle/boarded, not during launch/arrival) ─
           const rd = rocketDataRef.current;
           if (rd && (rd.state === 'idle' || rd.state === 'boarded') && cameraRef.current) {
             // Place player at the base of the rocket
@@ -2938,11 +2938,14 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
             playerRef.current.velY = 0;
             playerRef.current.onGround = true;
             rd.state = 'idle';
+            // Only detach player from rocket when exiting in idle/boarded state.
+            // During launch/countdown/arrived/docked the E key is a no-op here
+            // (arrived is handled by the space-station entry block above).
+            onRocketRef.current = false;
+            setOnRocket(false);
+            setRocketCountdown(null);
+            if (weaponMeshRef.current) weaponMeshRef.current.visible = cameraModeRef.current === "first";
           }
-          onRocketRef.current = false;
-          setOnRocket(false);
-          setRocketCountdown(null);
-          if (weaponMeshRef.current) weaponMeshRef.current.visible = cameraModeRef.current === "first";
         } else if (nearRocketForBoardRef.current && !possessedSheepRef.current && !onBoatRef.current) {
           // ── Board the rocket ────────────────────────────────────────────────
           const rd = rocketDataRef.current;

--- a/liquid-glass-clock/docs/rocket-system.md
+++ b/liquid-glass-clock/docs/rocket-system.md
@@ -91,7 +91,7 @@ Handles all rocket state transitions each frame:
 | Key | Action |
 |-----|--------|
 | `E` | Board rocket (when nearby in idle state) |
-| `E` | Exit rocket (when in idle/boarded state) |
+| `E` | Exit rocket (only in idle/boarded state — no-op during launch/countdown/arrived/docked) |
 | `E` | Enter space station (when `arrived` at Mothership) |
 | `Space` | Initiate countdown (when boarded) |
 


### PR DESCRIPTION
## Summary

Opraveno. Chyba byla v E key handleru v `Game3D.tsx`: volání `onRocketRef.current = false` a `setOnRocket(false)` probíhalo **vždy** při stisku E na raketě – i při stavech `launching`, `countdown`, `arrived` a `docked`. Díky tomu, pokud hráč omylem stiskl E během letu, byl odpojen od rakety ve vzduchu a spadl zpět na zem.

**Oprava:** přesunul jsem odhlášení z rakety dovnitř podmínky `if (rd.state === 'idle' || rd.state === 'boarded')` – stisk E je tedy v ostatních stavech no-op. Stav `arrived` je správně ošetřen dřívějším blokem pro vstup do vesmírné stanice. Přidáno 7 nových unit testů ověřující toto chování.

## Commits

- fix: prevent mid-flight rocket ejection when pressing E
- feat: add procedural terrain textures with triplanar mapping
- perf: triple grass density (60k → 180k blades) with adaptive LOD geometry