### PR TITLE
Umozni pokladani objektu do sveta - kdyz budu drzet napriklad dyni, chci ji moct polozit.

### DIFF
--- a/liquid-glass-clock/__tests__/buildingSystem.test.ts
+++ b/liquid-glass-clock/__tests__/buildingSystem.test.ts
@@ -30,7 +30,10 @@ import {
   blockKey,
   saveBlocks,
   loadBlocks,
+  saveWorldItems,
+  loadWorldItems,
 } from "../lib/buildingSystem";
+import type { PlacedWorldItemData } from "../lib/gameTypes";
 import {
   BLOCK_DEFS,
   BLOCK_MATERIAL_ORDER,
@@ -302,5 +305,86 @@ describe("BLOCK_DEFS", () => {
 
   it("all 8 materials are present", () => {
     expect(BLOCK_MATERIAL_ORDER).toHaveLength(8);
+  });
+});
+
+// ─── saveWorldItems / loadWorldItems ──────────────────────────────────────────
+
+describe("saveWorldItems", () => {
+  beforeEach(() => localStorageMock.clear());
+
+  it("persists a pumpkin placement to localStorage", () => {
+    const item: PlacedWorldItemData = { type: "pumpkin", x: 10, y: 2.5, z: -8, rotY: 1.2 };
+    saveWorldItems([item]);
+    expect(localStorageMock.setItem).toHaveBeenCalled();
+    const stored = JSON.parse(localStorageMock.setItem.mock.calls.at(-1)![1]);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].type).toBe("pumpkin");
+    expect(stored[0].x).toBe(10);
+  });
+
+  it("persists multiple items", () => {
+    const items: PlacedWorldItemData[] = [
+      { type: "pumpkin", x: 0, y: 0, z: 0, rotY: 0 },
+      { type: "pumpkin", x: 5, y: 0, z: 5, rotY: 1.0 },
+    ];
+    saveWorldItems(items);
+    const stored = JSON.parse(localStorageMock.setItem.mock.calls.at(-1)![1]);
+    expect(stored).toHaveLength(2);
+  });
+
+  it("persists an empty list", () => {
+    saveWorldItems([]);
+    const stored = JSON.parse(localStorageMock.setItem.mock.calls.at(-1)![1]);
+    expect(stored).toEqual([]);
+  });
+});
+
+describe("loadWorldItems", () => {
+  beforeEach(() => localStorageMock.clear());
+
+  it("returns empty array when nothing is stored", () => {
+    localStorageMock.getItem.mockReturnValueOnce(null);
+    expect(loadWorldItems()).toEqual([]);
+  });
+
+  it("round-trips a saved pumpkin placement", () => {
+    const items: PlacedWorldItemData[] = [
+      { type: "pumpkin", x: 12, y: 1.0, z: -7, rotY: 0.5 },
+    ];
+    saveWorldItems(items);
+    // Simulate localStorage returning what was stored
+    const saved = localStorageMock.setItem.mock.calls.at(-1)![1];
+    localStorageMock.getItem.mockReturnValueOnce(saved);
+    const loaded = loadWorldItems();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].type).toBe("pumpkin");
+    expect(loaded[0].x).toBe(12);
+    expect(loaded[0].z).toBe(-7);
+    expect(loaded[0].rotY).toBe(0.5);
+  });
+
+  it("filters out entries with unknown item type", () => {
+    const raw = JSON.stringify([
+      { type: "unknown_item", x: 0, y: 0, z: 0, rotY: 0 },
+      { type: "pumpkin", x: 1, y: 0, z: 1, rotY: 0 },
+    ]);
+    localStorageMock.getItem.mockReturnValueOnce(raw);
+    const loaded = loadWorldItems();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].type).toBe("pumpkin");
+  });
+
+  it("filters out entries with missing numeric fields", () => {
+    const raw = JSON.stringify([
+      { type: "pumpkin", x: "not-a-number", y: 0, z: 0, rotY: 0 },
+    ]);
+    localStorageMock.getItem.mockReturnValueOnce(raw);
+    expect(loadWorldItems()).toEqual([]);
+  });
+
+  it("returns empty array on invalid JSON", () => {
+    localStorageMock.getItem.mockReturnValueOnce("not json {{");
+    expect(loadWorldItems()).toEqual([]);
   });
 });

--- a/liquid-glass-clock/__tests__/meshBuilders.test.ts
+++ b/liquid-glass-clock/__tests__/meshBuilders.test.ts
@@ -42,6 +42,7 @@ import {
   buildMotherShipMesh,
   buildRocketMesh,
   buildSpaceStationInterior,
+  buildPumpkinMesh,
 } from "@/lib/meshBuilders";
 import * as THREE from "three";
 
@@ -1138,5 +1139,62 @@ describe("buildSpaceStationInterior", () => {
     });
     // Bridge extends to X ≥ 55 (defined as X: 35..58)
     expect(maxX).toBeGreaterThanOrEqual(50);
+  });
+});
+
+// ─── buildPumpkinMesh ─────────────────────────────────────────────────────────
+
+describe("buildPumpkinMesh", () => {
+  it("returns a THREE.Group", () => {
+    const group = buildPumpkinMesh();
+    expect(group).toBeInstanceOf(THREE.Group);
+  });
+
+  it("has children (body + ribs + stem + leaf)", () => {
+    const group = buildPumpkinMesh();
+    expect(group.children.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("uses default scale 1.0 when no argument given", () => {
+    const group = buildPumpkinMesh();
+    expect(group.scale.x).toBeCloseTo(1.0);
+    expect(group.scale.y).toBeCloseTo(1.0);
+    expect(group.scale.z).toBeCloseTo(1.0);
+  });
+
+  it("applies custom scale uniformly", () => {
+    const group = buildPumpkinMesh(0.55);
+    expect(group.scale.x).toBeCloseTo(0.55);
+    expect(group.scale.y).toBeCloseTo(0.55);
+    expect(group.scale.z).toBeCloseTo(0.55);
+  });
+
+  it("hand-held version (scale 0.55) is smaller than world version (scale 1.0)", () => {
+    const worldGroup = buildPumpkinMesh(1.0);
+    const handGroup = buildPumpkinMesh(0.55);
+    expect(handGroup.scale.x).toBeLessThan(worldGroup.scale.x);
+  });
+
+  it("all mesh children have a material", () => {
+    const group = buildPumpkinMesh();
+    let meshCount = 0;
+    group.traverse((child) => {
+      const m = child as THREE.Mesh;
+      if (m.isMesh) {
+        expect(m.material).toBeTruthy();
+        meshCount++;
+      }
+    });
+    expect(meshCount).toBeGreaterThan(0);
+  });
+
+  it("pumpkin body mesh uses orange-ish colour", () => {
+    const group = buildPumpkinMesh();
+    // First child should be the main body mesh
+    const body = group.children[0] as THREE.Mesh;
+    expect(body).toBeInstanceOf(THREE.Mesh);
+    const mat = body.material as THREE.MeshLambertMaterial;
+    // Orange colour: red channel dominant
+    expect(mat.color.r).toBeGreaterThan(mat.color.b);
   });
 });

--- a/liquid-glass-clock/components/Game3D.tsx
+++ b/liquid-glass-clock/components/Game3D.tsx
@@ -38,6 +38,8 @@ import {
   blockKey,
   saveBlocks,
   loadBlocks,
+  saveWorldItems,
+  loadWorldItems,
 } from "@/lib/buildingSystem";
 import {
   buildSheepMesh,
@@ -60,11 +62,12 @@ import {
   buildMotherShipMesh,
   buildRocketMesh,
   buildSpaceStationInterior,
+  buildPumpkinMesh,
   type SpaceStationInteriorResult,
   type SheepMeshParts,
   type RuinsResult,
 } from "@/lib/meshBuilders";
-import type { SheepData, FoxData, CoinData, BulletData, CatapultData, CannonballData, ImpactEffect, GameState, WeaponType, BloodParticle, RocketData } from "@/lib/gameTypes";
+import type { SheepData, FoxData, CoinData, BulletData, CatapultData, CannonballData, ImpactEffect, GameState, WeaponType, BloodParticle, RocketData, WorldItem, PlacedWorldItemData, WorldItemType } from "@/lib/gameTypes";
 import { WEAPON_CONFIGS } from "@/lib/gameTypes";
 import { soundManager } from "@/lib/soundManager";
 import {
@@ -185,6 +188,14 @@ const SWIM_SPEED = 5.5;         // units/second when swimming in water
 const DIVE_SPEED = 5.0;         // units/second when actively diving down (Ctrl)
 const SWIM_RISE_SPEED = 6.0;    // units/second when actively swimming up (Space)
 const SWIM_BUOYANCY = 5.0;      // upward drift speed per second (natural buoyancy when submerged)
+
+// ─── World Item (pickup / placement) Constants ────────────────────────────────
+/** Radius within which the player can pick up a world item (press E). */
+const PICKUP_RADIUS = 2.8;
+/** Default number of pumpkins spawned in the world at game start. */
+const PUMPKIN_COUNT = IS_MOBILE ? 3 : 6;
+/** Camera-local position of the held-item mesh (right-hand, lower screen). */
+const HELD_ITEM_POS = new THREE.Vector3(0.28, -0.30, -0.55);
 
 // ─── Third-person Camera Constants ───────────────────────────────────────────
 const TP_DISTANCE = 6;   // camera distance behind player in 3rd-person view
@@ -419,6 +430,18 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
   const sculptIndicatorRef = useRef<THREE.Mesh | null>(null);
   const buildRaycasterRef = useRef(new THREE.Raycaster());
 
+  // ─── World Items (pickable / placeable objects) ───────────────────────────────
+  /** All world item instances currently in the scene (including held ones). */
+  const worldItemsRef = useRef<WorldItem[]>([]);
+  /** The item the player is currently holding (null if empty-handed). */
+  const heldItemRef = useRef<WorldItem | null>(null);
+  /** Camera-space mesh shown in first-person when holding an item. */
+  const heldItemHandMeshRef = useRef<THREE.Group | null>(null);
+  /** Ghost preview mesh for item placement targeting. */
+  const itemPlacementGhostRef = useRef<THREE.Group | null>(null);
+  /** Nearest pickable item within PICKUP_RADIUS (updated per frame). */
+  const nearestPickableItemRef = useRef<WorldItem | null>(null);
+
   // ─── Possession Refs ─────────────────────────────────────────────────────────
   const possessedSheepRef = useRef<SheepData | null>(null);
   const nearestSheepForPossessRef = useRef<SheepData | null>(null);
@@ -488,6 +511,8 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     selectedMaterial: "wood",
     blockCount: 0,
   });
+  const [nearItemPrompt, setNearItemPrompt] = useState<WorldItemType | null>(null);
+  const [heldItemType, setHeldItemType] = useState<WorldItemType | null>(null);
   const [nearSheepPrompt, setNearSheepPrompt] = useState(false);
   const [isPossessed, setIsPossessed] = useState(false);
   const [nearBoatPrompt, setNearBoatPrompt] = useState(false);
@@ -797,6 +822,77 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     });
   }
 
+  // ─── World item: pick up the nearest item ────────────────────────────────────
+  function pickUpItem(item: WorldItem) {
+    if (!cameraRef.current || !sceneRef.current) return;
+    const cam = cameraRef.current;
+
+    // Hide world mesh (item stays in array but is no longer visible in world)
+    item.mesh.visible = false;
+    item.isHeld = true;
+    heldItemRef.current = item;
+    setHeldItemType(item.type);
+
+    // Build and attach hand mesh to camera
+    const handMesh = buildPumpkinMesh(0.55);
+    handMesh.position.copy(HELD_ITEM_POS);
+    // Tilt slightly so it looks held naturally
+    handMesh.rotation.set(0.15, -0.3, 0.1);
+    cam.add(handMesh);
+    heldItemHandMeshRef.current = handMesh;
+
+    // Hide weapon while holding item
+    if (weaponMeshRef.current) weaponMeshRef.current.visible = false;
+  }
+
+  // ─── World item: place the held item at a target world position ───────────────
+  function placeHeldItem(targetPos: THREE.Vector3, targetRotY: number) {
+    const held = heldItemRef.current;
+    if (!held || !cameraRef.current || !sceneRef.current) return;
+
+    // Move the world mesh to the target position and show it
+    held.mesh.position.copy(targetPos);
+    held.mesh.rotation.y = targetRotY;
+    held.mesh.visible = true;
+    held.isHeld = false;
+
+    // Remove hand mesh from camera
+    const cam = cameraRef.current;
+    if (heldItemHandMeshRef.current) {
+      cam.remove(heldItemHandMeshRef.current);
+      heldItemHandMeshRef.current = null;
+    }
+
+    heldItemRef.current = null;
+    setHeldItemType(null);
+
+    // Restore weapon visibility in first-person mode
+    if (weaponMeshRef.current && cameraModeRef.current === "first") {
+      weaponMeshRef.current.visible = true;
+    }
+
+    // Persist placement
+    const items: PlacedWorldItemData[] = worldItemsRef.current
+      .filter((wi) => !wi.isHeld)
+      .map((wi) => ({
+        type: wi.type,
+        x: wi.mesh.position.x,
+        y: wi.mesh.position.y,
+        z: wi.mesh.position.z,
+        rotY: wi.mesh.rotation.y,
+      }));
+    saveWorldItems(items);
+  }
+
+  // ─── World item: drop the held item at the player's feet ─────────────────────
+  function dropHeldItem() {
+    const held = heldItemRef.current;
+    if (!held || !cameraRef.current) return;
+    const cam = cameraRef.current;
+    const groundY = getTerrainHeightSampled(cam.position.x, cam.position.z);
+    placeHeldItem(new THREE.Vector3(cam.position.x, groundY, cam.position.z), cam.rotation.y);
+  }
+
   // ─── Flash sheep mesh red when hit ───────────────────────────────────────────
   function flashSheepMesh(mesh: THREE.Group) {
     mesh.traverse((child) => {
@@ -855,8 +951,9 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     if (!isLockedRef.current) return;
     if (playerAttackCooldownRef.current > 0) return;
     if (!cameraRef.current || !sceneRef.current) return;
-    // Cannot attack while controlling a vehicle, possessing a sheep, or in the space station
+    // Cannot attack while controlling a vehicle, possessing a sheep, in the space station, or holding an item
     if (possessedSheepRef.current || onBoatRef.current || onRocketRef.current || inSpaceStationRef.current) return;
+    if (heldItemRef.current) return; // holding an item — must place it first
 
     const weaponCfg = WEAPON_CONFIGS[selectedWeaponRef.current];
 
@@ -1592,6 +1689,72 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     });
     if (savedBlocks.length > 0) {
       setBuildingUiState((s) => ({ ...s, blockCount: savedBlocks.length }));
+    }
+
+    // ── World items: placement ghost ─────────────────────────────────────────
+    const itemGhost = buildPumpkinMesh(1.0);
+    itemGhost.traverse((child) => {
+      const m = child as THREE.Mesh;
+      if (m.isMesh && m.material) {
+        const mat = (m.material as THREE.MeshLambertMaterial).clone();
+        mat.transparent = true;
+        mat.opacity = 0.45;
+        mat.depthWrite = false;
+        m.material = mat;
+      }
+    });
+    itemGhost.visible = false;
+    scene.add(itemGhost);
+    itemPlacementGhostRef.current = itemGhost;
+
+    // ── World items: spawn initial pumpkins ──────────────────────────────────
+    // Fixed spawn positions scattered around the world (near landmarks / paths)
+    const pumpkinSpawns: Array<{ x: number; z: number; rotY: number }> = [
+      { x: -24, z: 18,  rotY: 0.5 },  // near farmhouse
+      { x:  30, z: 32,  rotY: 1.2 },  // near windmill
+      { x:   8, z: -12, rotY: 2.4 },  // near spawn
+      { x: -10, z: -8,  rotY: 0.8 },  // near spawn
+      { x:  45, z: -35, rotY: 3.1 },  // open field
+      { x: -50, z: 55,  rotY: 1.9 },  // northwest field
+    ];
+    const spawnSubset = pumpkinSpawns.slice(0, PUMPKIN_COUNT);
+
+    // First check if there are user-placed items saved from a previous session
+    const savedWorldItems = loadWorldItems();
+    if (savedWorldItems.length > 0) {
+      // Restore saved placements (overrides default spawns)
+      savedWorldItems.forEach((saved) => {
+        const mesh = buildPumpkinMesh(1.0);
+        const groundY = getTerrainHeightSampled(saved.x, saved.z);
+        mesh.position.set(saved.x, groundY, saved.z);
+        mesh.rotation.y = saved.rotY;
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        scene.add(mesh);
+        worldItemsRef.current.push({
+          id: Math.random().toString(36).slice(2),
+          type: saved.type,
+          mesh,
+          isHeld: false,
+        });
+      });
+    } else {
+      // Default spawns at game start
+      spawnSubset.forEach(({ x, z, rotY }) => {
+        const mesh = buildPumpkinMesh(1.0);
+        const groundY = getTerrainHeightSampled(x, z);
+        mesh.position.set(x, groundY, z);
+        mesh.rotation.y = rotY;
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        scene.add(mesh);
+        worldItemsRef.current.push({
+          id: Math.random().toString(36).slice(2),
+          type: "pumpkin",
+          mesh,
+          isHeld: false,
+        });
+      });
     }
 
     // ── Water ───────────────────────────────────────────────────────────────
@@ -2805,10 +2968,35 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     }
 
     // ── Input ─────────────────────────────────────────────────────────────────
+    // ── Helper: place held item via raycast from camera ───────────────────────
+    const tryPlaceHeldItemViaRaycast = (): boolean => {
+      if (!heldItemRef.current || !cameraRef.current || !terrainMeshRef.current) return false;
+      const cam = cameraRef.current;
+      const raycaster = buildRaycasterRef.current;
+      raycaster.setFromCamera(new THREE.Vector2(0, 0), cam);
+      // Gather objects to intersect: terrain + placed blocks
+      const targets: THREE.Object3D[] = [terrainMeshRef.current, ...Array.from(placedBlockMeshesRef.current.values())];
+      const hits = raycaster.intersectObjects(targets, false);
+      if (hits.length > 0) {
+        const hit = hits[0];
+        // Place on top of the hit surface
+        const pos = hit.point.clone();
+        pos.y = getTerrainHeightSampled(pos.x, pos.z);
+        placeHeldItem(pos, cam.rotation.y);
+        return true;
+      }
+      return false;
+    };
+
     // ── Mouse click — attack OR build depending on current mode ───────────────
     const onMouseDown = (e: MouseEvent) => {
       if (!isLockedRef.current) return;
       if (e.button === 0) {
+        // If holding an item, left click places it
+        if (heldItemRef.current && buildModeRef.current === "explore") {
+          tryPlaceHeldItemViaRaycast();
+          return;
+        }
         if (buildModeRef.current === "build") {
           if (ghostMeshRef.current?.visible) {
             placeBlock(ghostMeshRef.current.position.clone());
@@ -2865,9 +3053,13 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
     const onKey = (e: KeyboardEvent) => {
       keysRef.current[e.code] = e.type === "keydown";
 
-      // F key attack (only in explore mode)
+      // F key: place held item (if carrying one) OR attack in explore mode
       if (e.type === "keydown" && e.code === "KeyF" && buildModeRef.current === "explore") {
-        doAttack();
+        if (heldItemRef.current) {
+          tryPlaceHeldItemViaRaycast();
+        } else {
+          doAttack();
+        }
       }
 
       // E key: board/exit boat, board rocket, enter/exit space station, OR possess/unpossess nearby sheep
@@ -2987,6 +3179,14 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
           onBoatRef.current = true;
           setOnBoat(true);
           if (weaponMeshRef.current) weaponMeshRef.current.visible = false;
+        } else if (heldItemRef.current) {
+          // ── Drop held item at player's feet ──────────────────────────────
+          dropHeldItem();
+        } else if (nearestPickableItemRef.current && !possessedSheepRef.current) {
+          // ── Pick up nearby item ───────────────────────────────────────────
+          pickUpItem(nearestPickableItemRef.current);
+          nearestPickableItemRef.current = null;
+          setNearItemPrompt(null);
         } else if (possessedSheepRef.current) {
           // Exit possession — place player above the sheep's current position
           const sheep = possessedSheepRef.current;
@@ -5230,6 +5430,55 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
         );
       }
 
+      // ── World items: proximity pickup check + placement ghost ─────────────────
+      if (!possessedSheepRef.current && !onBoatRef.current && !inSpaceStationRef.current) {
+        if (heldItemRef.current) {
+          // Show placement ghost at terrain surface in front of player
+          const ghost = itemPlacementGhostRef.current;
+          if (ghost && cameraRef.current && terrainMeshRef.current) {
+            const cam = cameraRef.current;
+            const raycaster = buildRaycasterRef.current;
+            raycaster.setFromCamera(new THREE.Vector2(0, 0), cam);
+            const targets: THREE.Object3D[] = [terrainMeshRef.current, ...Array.from(placedBlockMeshesRef.current.values())];
+            const hits = raycaster.intersectObjects(targets, false);
+            if (hits.length > 0 && hits[0].distance < BUILD_RANGE + 2) {
+              const hp = hits[0].point;
+              const groundY = getTerrainHeightSampled(hp.x, hp.z);
+              ghost.position.set(hp.x, groundY, hp.z);
+              ghost.visible = buildModeRef.current === "explore";
+            } else {
+              ghost.visible = false;
+            }
+          }
+          // Nearest pickable is irrelevant while holding
+          nearestPickableItemRef.current = null;
+          setNearItemPrompt(null);
+        } else {
+          // Hide ghost when not holding
+          if (itemPlacementGhostRef.current) itemPlacementGhostRef.current.visible = false;
+          // Find nearest non-held world item within PICKUP_RADIUS
+          let bestDist = PICKUP_RADIUS;
+          let bestItem: WorldItem | null = null;
+          worldItemsRef.current.forEach((wi) => {
+            if (wi.isHeld) return;
+            const dx = wi.mesh.position.x - playerPos.x;
+            const dz = wi.mesh.position.z - playerPos.z;
+            const dist = Math.sqrt(dx * dx + dz * dz);
+            if (dist < bestDist) {
+              bestDist = dist;
+              bestItem = wi;
+            }
+          });
+          nearestPickableItemRef.current = bestItem;
+          const nearItem = bestItem as WorldItem | null;
+          setNearItemPrompt(nearItem ? nearItem.type : null);
+        }
+      } else {
+        if (itemPlacementGhostRef.current) itemPlacementGhostRef.current.visible = false;
+        nearestPickableItemRef.current = null;
+        setNearItemPrompt(null);
+      }
+
       // ── Possession proximity — find nearest sheep, manage highlight ──────────
       if (!possessedSheepRef.current) {
         let nearestDist = POSSESS_RADIUS;
@@ -6415,6 +6664,46 @@ export default function Game3D({ playerName = "Hráč" }: { playerName?: string 
             }}
           >
             🚀 [E] Airlock – vrátit se na Zemi
+          </div>
+        </div>
+      )}
+
+      {/* ═══════════════ CENTER — Pickup item prompt ═══════════════ */}
+      {nearItemPrompt && !heldItemType && !isPossessed && !onBoat && gameState.isLocked && (
+        <div className="fixed bottom-36 left-1/2 -translate-x-1/2 pointer-events-none select-none">
+          <div
+            className="rounded-xl text-white font-bold text-sm animate-pulse"
+            style={{
+              padding: "10px 24px",
+              background: "rgba(80,50,10,0.88)",
+              backdropFilter: "blur(10px)",
+              border: "1px solid rgba(230,140,40,0.45)",
+              boxShadow: "0 0 20px rgba(200,100,0,0.40)",
+            }}
+          >
+            🎃 [E] Vzít {nearItemPrompt === "pumpkin" ? "dýni" : nearItemPrompt}
+          </div>
+        </div>
+      )}
+
+      {/* ═══════════════ BOTTOM CENTER — Held item indicator ═══════════════ */}
+      {heldItemType && gameState.isLocked && (
+        <div className="fixed bottom-28 left-1/2 -translate-x-1/2 pointer-events-none select-none">
+          <div
+            className="rounded-xl text-white font-bold text-sm"
+            style={{
+              padding: "10px 28px",
+              background: "rgba(80,40,5,0.90)",
+              backdropFilter: "blur(10px)",
+              border: "1px solid rgba(240,150,30,0.50)",
+              boxShadow: "0 0 22px rgba(200,100,0,0.45)",
+            }}
+          >
+            🎃 {heldItemType === "pumpkin" ? "Dýně" : heldItemType} v ruce
+            &nbsp;·&nbsp;
+            <span style={{ color: "#fcd34d" }}>[Klik / F] Položit</span>
+            &nbsp;·&nbsp;
+            <span style={{ color: "#fca5a5" }}>[E] Upustit</span>
           </div>
         </div>
       )}

--- a/liquid-glass-clock/docs/world-items-system.md
+++ b/liquid-glass-clock/docs/world-items-system.md
@@ -1,0 +1,83 @@
+# World Items System
+
+Pickable and placeable objects that exist in the 3D world.
+
+## Overview
+
+Players can pick up specific objects (e.g. pumpkins) scattered around the world, carry them in their hand, and place them at any target location. Placements are saved to `localStorage` and restored on reload.
+
+## Architecture
+
+### Data Types (`lib/gameTypes.ts`)
+
+| Type | Description |
+|------|-------------|
+| `WorldItemType` | Union type of all placeable item types (`"pumpkin"`) |
+| `WorldItem` | Runtime item: `id`, `type`, `mesh`, `isHeld` |
+| `PlacedWorldItemData` | Serialisable snapshot: `type`, `x`, `y`, `z`, `rotY` |
+
+### Mesh Builder (`lib/meshBuilders.ts`)
+
+`buildPumpkinMesh(scale = 1.0): THREE.Group`
+
+- Builds a pumpkin from primitive geometries: flattened body sphere, 4 rib spheres, cylindrical stem, torus leaf curl.
+- Call with `scale = 1.0` for world placements and `scale = 0.55` for the hand-held first-person view.
+
+### Persistence (`lib/buildingSystem.ts`)
+
+| Function | Description |
+|----------|-------------|
+| `saveWorldItems(items)` | Serialises placed item data to `localStorage` (key `game3d_world_items_v1`) |
+| `loadWorldItems()` | Restores saved items; validates type and numeric fields; returns `[]` on missing/invalid data |
+
+### Game Logic (`components/Game3D.tsx`)
+
+**Constants**
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `PICKUP_RADIUS` | 2.8 | Distance within which E key picks up items |
+| `PUMPKIN_COUNT` | 6 (desktop) / 3 (mobile) | Default world spawns |
+| `HELD_ITEM_POS` | `(0.28, -0.30, -0.55)` | Camera-local position of hand mesh |
+
+**Refs**
+
+| Ref | Type | Description |
+|-----|------|-------------|
+| `worldItemsRef` | `WorldItem[]` | All items in the scene |
+| `heldItemRef` | `WorldItem \| null` | Currently held item |
+| `heldItemHandMeshRef` | `THREE.Group \| null` | Camera-attached hand mesh |
+| `itemPlacementGhostRef` | `THREE.Group \| null` | Ghost preview for placement |
+| `nearestPickableItemRef` | `WorldItem \| null` | Nearest item within pickup radius |
+
+**State**
+
+| State | Type | Description |
+|-------|------|-------------|
+| `nearItemPrompt` | `WorldItemType \| null` | Drives pickup HUD prompt |
+| `heldItemType` | `WorldItemType \| null` | Drives held-item HUD indicator |
+
+## Controls
+
+| Key / Action | Behaviour |
+|---|---|
+| `E` near item (empty-handed) | Pick up the nearest item |
+| `E` while holding | Drop item at player's feet |
+| `Left Click` / `F` while holding | Raycast-place item on terrain surface |
+
+## Player State Interactions
+
+- **Cannot attack** while holding an item (`doAttack` guards `heldItemRef.current`).
+- **Weapon mesh hidden** while holding; restored when item is placed/dropped.
+- **Ghost preview hidden** during build mode, in boat, on rocket, or in space station.
+- **Cannot pick up items** while possessing a sheep or aboard a vehicle.
+
+## Initialization
+
+1. Ghost mesh created once and added to scene (invisible by default).
+2. Saved items loaded from `localStorage` via `loadWorldItems()`.
+3. If no saved items, default spawn positions are used (fixed coordinates near landmarks).
+
+## Saving
+
+Placements are saved after every `placeHeldItem()` call. Only non-held items are serialised. The save includes absolute world position and Y rotation.

--- a/liquid-glass-clock/lib/buildingSystem.ts
+++ b/liquid-glass-clock/lib/buildingSystem.ts
@@ -12,6 +12,10 @@ import {
   PlacedBlockData,
   BLOCKS_STORAGE_KEY,
 } from "./buildingTypes";
+import type { PlacedWorldItemData, WorldItemType } from "./gameTypes";
+
+// ─── World item persistence storage key ──────────────────────────────────────
+const WORLD_ITEMS_STORAGE_KEY = "game3d_world_items_v1";
 
 // ─── Shared geometry (avoids allocating a new BoxGeometry per block) ──────────
 const _boxGeo = new THREE.BoxGeometry(BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE);
@@ -156,6 +160,38 @@ export function loadBlocks(): PlacedBlockData[] {
         z,
         material: order[mi],
       }));
+  } catch {
+    return [];
+  }
+}
+
+// ─── World item persistence ────────────────────────────────────────────────────
+
+/** Serialize placed world items to localStorage. */
+export function saveWorldItems(items: PlacedWorldItemData[]): void {
+  try {
+    localStorage.setItem(WORLD_ITEMS_STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // localStorage might be unavailable (private mode, quota exceeded)
+  }
+}
+
+/** Load placed world items from localStorage. Returns empty array if nothing saved. */
+export function loadWorldItems(): PlacedWorldItemData[] {
+  const validTypes: WorldItemType[] = ["pumpkin"];
+  try {
+    const raw = localStorage.getItem(WORLD_ITEMS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as PlacedWorldItemData[];
+    return parsed.filter(
+      (item) =>
+        item &&
+        typeof item.x === "number" &&
+        typeof item.y === "number" &&
+        typeof item.z === "number" &&
+        typeof item.rotY === "number" &&
+        validTypes.includes(item.type)
+    );
   } catch {
     return [];
   }

--- a/liquid-glass-clock/lib/gameTypes.ts
+++ b/liquid-glass-clock/lib/gameTypes.ts
@@ -196,6 +196,32 @@ export interface GameState {
   attackReady: boolean;
 }
 
+// ─── World Item (pickable / placeable objects) ─────────────────────────────
+
+/** All types of objects that can be picked up and placed in the world. */
+export type WorldItemType = "pumpkin";
+
+/** A pickable/placeable object that exists in the 3D world. */
+export interface WorldItem {
+  /** Unique identifier (UUID). */
+  id: string;
+  type: WorldItemType;
+  /** The root Three.js group rendered in the scene. */
+  mesh: THREE.Group;
+  /** True while the player is holding this item (mesh is hidden from world). */
+  isHeld: boolean;
+}
+
+/** Serialisable snapshot of a placed world item (for localStorage persistence). */
+export interface PlacedWorldItemData {
+  type: WorldItemType;
+  x: number;
+  y: number;
+  z: number;
+  /** Y-axis rotation in radians at the time of placement. */
+  rotY: number;
+}
+
 // ─── Rocket system ─────────────────────────────────────────────────────────
 export type RocketState = 'idle' | 'boarded' | 'countdown' | 'launching' | 'arrived' | 'docked';
 

--- a/liquid-glass-clock/lib/meshBuilders.ts
+++ b/liquid-glass-clock/lib/meshBuilders.ts
@@ -2677,3 +2677,61 @@ export function buildSpaceStationInterior(): SpaceStationInteriorResult {
     animatedMeshes,
   };
 }
+
+// ─── Pumpkin (pickable world item) ───────────────────────────────────────────
+
+/**
+ * Builds a pumpkin mesh for placement in the world.
+ * The group origin is at the bottom centre of the pumpkin so it sits flush
+ * on the terrain.
+ *
+ * @param scale - uniform scale multiplier (default 1.0). Pass ~0.55 for the
+ *   hand-held "held item" version shown in first-person view.
+ */
+export function buildPumpkinMesh(scale = 1.0): THREE.Group {
+  const group = new THREE.Group();
+
+  const orangeMat = new THREE.MeshLambertMaterial({ color: 0xe07820 });
+  const darkOrangeMat = new THREE.MeshLambertMaterial({ color: 0xb85010 });
+  const greenMat = new THREE.MeshLambertMaterial({ color: 0x3a8a20 });
+  const darkGreenMat = new THREE.MeshLambertMaterial({ color: 0x246010 });
+
+  // ── Main body (slightly flattened sphere) ──────────────────────────────────
+  const bodyGeo = new THREE.SphereGeometry(0.42, 10, 8);
+  // Flatten vertically to make it look more like a pumpkin
+  const bodyMesh = new THREE.Mesh(bodyGeo, orangeMat);
+  bodyMesh.scale.y = 0.78;
+  bodyMesh.position.y = 0.33; // sit on ground
+  group.add(bodyMesh);
+
+  // ── Ribs (4 vertical elongated spheres overlaid for the segmented look) ────
+  for (let i = 0; i < 4; i++) {
+    const angle = (i / 4) * Math.PI * 2;
+    const ribGeo = new THREE.SphereGeometry(0.16, 6, 6);
+    const rib = new THREE.Mesh(ribGeo, darkOrangeMat);
+    rib.scale.set(1.0, 1.4, 1.0);
+    rib.position.set(
+      Math.cos(angle) * 0.28,
+      0.33,
+      Math.sin(angle) * 0.28
+    );
+    group.add(rib);
+  }
+
+  // ── Stem ──────────────────────────────────────────────────────────────────
+  const stemGeo = new THREE.CylinderGeometry(0.045, 0.07, 0.28, 6);
+  const stem = new THREE.Mesh(stemGeo, darkGreenMat);
+  stem.position.y = 0.72;
+  stem.rotation.z = 0.18; // slight lean
+  group.add(stem);
+
+  // ── Leaf curl (small torus arc on the stem) ──────────────────────────────
+  const leafGeo = new THREE.TorusGeometry(0.10, 0.025, 4, 8, Math.PI * 1.1);
+  const leaf = new THREE.Mesh(leafGeo, greenMat);
+  leaf.position.set(0.08, 0.80, 0.0);
+  leaf.rotation.set(Math.PI / 2, 0, 0.5);
+  group.add(leaf);
+
+  group.scale.setScalar(scale);
+  return group;
+}


### PR DESCRIPTION
## Summary

The implementation is complete. Here's a summary of what was done:

**Implemented a full object pickup and placement system** allowing players to pick up pumpkins scattered around the world and place them wherever they want:

1. **`E` key** (when near a pumpkin): picks it up — the pumpkin disappears from the world and appears held in the player's hand with a "🎃 [E] Vzít dýni" HUD prompt guiding them
2. **Left click or `F` key** while holding: raycast-places the pumpkin on the terrain surface at the crosshair target, with a translucent ghost preview showing exact placement position
3. **`E` key** while holding: drops the pumpkin at the player's feet

The system is fully extensible via the `WorldItemType` union. Six pumpkins spawn at fixed world locations by default (3 on mobile), and all placements persist to `localStorage` across sessions. The weapon is hidden while carrying an item and attacks are blocked. 15 new tests (7 for pumpkin mesh, 8 for persistence) all pass, and the build compiles cleanly.

## Commits

- feat: add world item pickup and placement system (pumpkins)